### PR TITLE
Feat: Login normal & admin user api (LocalGuard)

### DIFF
--- a/src/database/seeds/users.seed.ts
+++ b/src/database/seeds/users.seed.ts
@@ -1,5 +1,6 @@
 import { Factory, Seeder } from 'typeorm-seeding';
 
+import { hash } from 'bcrypt';
 import { User } from 'src/entities/users.entity';
 import { UserType } from 'src/types/users.types';
 import { Connection } from 'typeorm';
@@ -8,6 +9,7 @@ const seedAdminUserData = {
 	name: 'testAdmin',
 	nickname: 'testAdmin',
 	email: 'testAdmin@gmail.com',
+	password: 'testAdmin',
 	type: UserType.Admin,
 };
 
@@ -23,6 +25,9 @@ export default class UsersSeed implements Seeder {
 			})
 			.getOne();
 
-		if (!currentAdminuser) await connection.getRepository(User).save(seedAdminUserData);
+		if (!currentAdminuser) {
+			seedAdminUserData.password = await hash(seedAdminUserData.password, 10);
+			await connection.getRepository(User).save(seedAdminUserData);
+		}
 	}
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,16 +1,18 @@
 import { Body, Controller, Get, Header, HttpCode, Post, Query, Redirect, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiTags } from '@nestjs/swagger';
+
 import { AuthUser, FacebookUser } from 'src/decorators/auth.decorator';
 import { UserType } from 'src/types/users.types';
-
 import { UserResponseDto } from '../users/dto/user-response.dto';
 import { ApiDocs } from './auth.docs';
 import { AuthService } from './auth.service';
+import { LoginRequestDto } from './dto/login-request.dto';
 import { OauthUserDto } from './dto/oauth-user.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
 import { JwtRefreshGuard } from './guards/jwt-refresh-auth.guard';
 import { KakaoAuthGuard } from './guards/kakao-auth.guard';
+import { LocalAuthGuard } from './guards/local-auth.guard';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -67,6 +69,14 @@ export class AuthController {
 	@ApiDocs.signUp('일반 회원가입')
 	async signUp(@Body() user: SignUpRequestDto) {
 		return await this.authService.signUp(user);
+	}
+
+	@Post('/login')
+	@ApiDocs.login('일반 로그인')
+	@UseGuards(LocalAuthGuard)
+	@ApiBody({ type: LoginRequestDto })
+	async login(@AuthUser() user: UserResponseDto) {
+		return await this.authService.login(user);
 	}
 
 	@UseGuards(JwtRefreshGuard)

--- a/src/modules/auth/auth.docs.ts
+++ b/src/modules/auth/auth.docs.ts
@@ -4,7 +4,8 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagg
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { AuthController } from './auth.controller';
 import { KakaoLoginRequestDto } from './dto/kakao-login-request.dto';
-import { OauthLoginResponseDto } from './dto/oauth-login-response.dto';
+import { LoginRequestDto } from './dto/login-request.dto';
+import { LoginResponseDto } from './dto/login-response.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
 import { SignUpResponseDto } from './dto/signup-response.dto';
 import { TokenRefreshRequestDto } from './dto/token-refresh-request.dto';
@@ -48,7 +49,7 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 			ApiResponse({
 				status: 201,
 				description: '',
-				type: OauthLoginResponseDto,
+				type: LoginResponseDto,
 			}),
 		);
 	},
@@ -73,7 +74,7 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 			ApiResponse({
 				status: 200,
 				description: '',
-				type: OauthLoginResponseDto,
+				type: LoginResponseDto,
 			}),
 		);
 	},
@@ -90,6 +91,22 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 				status: 201,
 				description: '',
 				type: SignUpResponseDto,
+			}),
+		);
+	},
+	login(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '일반 로그인',
+			}),
+			ApiBody({
+				type: LoginRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: LoginResponseDto,
 			}),
 		);
 	},

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { User } from 'src/entities/users.entity';
@@ -11,10 +12,12 @@ import { FacebookAuthStrategy } from './strategies/facebook-auth.strategy';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { KakaoAuthStrategy } from './strategies/kakao-auth.strategy';
+import { LocalStrategy } from './strategies/local.strategy';
 
 @Module({
 	imports: [
 		HttpModule,
+		PassportModule,
 		TypeOrmModule.forFeature([User]),
 		JwtModule.register({
 			secret: process.env.JWT_ACCESS_TOKEN_SECRET,
@@ -22,6 +25,14 @@ import { KakaoAuthStrategy } from './strategies/kakao-auth.strategy';
 		}),
 	],
 	controllers: [AuthController],
-	providers: [AuthService, KakaoAuthStrategy, JwtStrategy, JwtRefreshStrategy, HashPassword, FacebookAuthStrategy],
+	providers: [
+		AuthService,
+		KakaoAuthStrategy,
+		JwtStrategy,
+		JwtRefreshStrategy,
+		HashPassword,
+		FacebookAuthStrategy,
+		LocalStrategy,
+	],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -16,7 +16,7 @@ import { JwtConfig, OauthConfig } from 'src/config/config.constant';
 import { User } from 'src/entities/users.entity';
 import { UserType } from 'src/types/users.types';
 import { UserResponseDto } from '../users/dto/user-response.dto';
-import { OauthLoginResponseDto } from './dto/oauth-login-response.dto';
+import { LoginResponseDto } from './dto/login-response.dto';
 import { OauthUserDto } from './dto/oauth-user.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
 import { TokenRefreshResponseDto } from './dto/token-refresh-response.dto';
@@ -114,7 +114,7 @@ export class AuthService {
 		}
 	}
 
-	async login(user: UserResponseDto): Promise<OauthLoginResponseDto> {
+	async login(user: UserResponseDto): Promise<LoginResponseDto> {
 		try {
 			const payload = { id: user.id, role: user.type };
 			const jwtAccessTokenExpire: string = this.jwtAccessTokenExpireByType(user.type);
@@ -128,7 +128,7 @@ export class AuthService {
 				expiresIn: this.#jwtConfig.jwtRefreshTokenExpire,
 			});
 
-			return new OauthLoginResponseDto({
+			return new LoginResponseDto({
 				accessToken,
 				refreshToken,
 				user,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -139,9 +139,12 @@ export class AuthService {
 	}
 
 	async validateEmailPassword(email: string, password: string): Promise<UserResponseDto> {
-		const foundUser = await this.usersRepository.findOne({
-			where: { email, type: UserType.Normal },
-		});
+		const types = [UserType.Admin, UserType.Normal];
+		const foundUser = await this.usersRepository
+			.createQueryBuilder('user')
+			.where('user.email = :email', { email })
+			.andWhere('user.type IN (:...types)', { types })
+			.getOne();
 
 		if (!foundUser || !foundUser.password) {
 			throw new NotFoundException('User is not found');

--- a/src/modules/auth/dto/login-request.dto.ts
+++ b/src/modules/auth/dto/login-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, Length } from 'class-validator';
+
+export class LoginRequestDto {
+	@IsEmail()
+	@ApiProperty({ example: 'test@naver.com', description: '이메일' })
+	readonly email: string;
+
+	@IsString()
+	@Length(8, 24)
+	@ApiProperty({ example: '1234abcd!', description: '패스워드' })
+	password: string;
+}

--- a/src/modules/auth/dto/login-response.dto.ts
+++ b/src/modules/auth/dto/login-response.dto.ts
@@ -3,7 +3,7 @@ import { IsString } from 'class-validator';
 
 import { UserResponseDto } from 'src/modules/users/dto/user-response.dto';
 
-export class OauthLoginResponseDto {
+export class LoginResponseDto {
 	@IsString()
 	@ApiProperty({ description: 'access token' })
 	readonly accessToken: string;

--- a/src/modules/auth/guards/local-auth.guard.ts
+++ b/src/modules/auth/guards/local-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class LocalAuthGuard extends AuthGuard('local') {}

--- a/src/modules/auth/strategies/local.strategy.ts
+++ b/src/modules/auth/strategies/local.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-local';
+import { UserResponseDto } from 'src/modules/users/dto/user-response.dto';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+	constructor(private authService: AuthService) {
+		super({
+			usernameField: 'email',
+			passwordField: 'password',
+		});
+	}
+
+	async validate(email: string, password: string): Promise<UserResponseDto> {
+		return await this.authService.validateEmailPassword(email, password);
+	}
+}


### PR DESCRIPTION
## 개요
- **일반 회원가입 사용자와 관리자의 로그인 기능**을 구현했습니다.
- 클라이언트에게서 {email, password}를 받으면, LocalGuard를 통해 사용자 검증을 하고 Jwt-token을 생성해 반환하도록 구현했습니다.
## 작업사항
- **local-auth.guard.ts 생성**
- **local.strategy.ts 생성**
- **vaildationEmailPassword Func 생성** : 이메일, 패스워드 검증
- **(Fix) admin user seed data** : password 해싱