### PR TITLE
Chore: Modify Location set null & Spot cascade true

### DIFF
--- a/src/entities/locations.entity.ts
+++ b/src/entities/locations.entity.ts
@@ -10,7 +10,7 @@ export class Location extends CommonEntity {
 	name: string;
 
 	@OneToMany(() => Spot, (spot: Spot) => spot.location, {
-		cascade: false,
+		cascade: true,
 		eager: true,
 	})
 	spots: Spot[];

--- a/src/entities/spots.entity.ts
+++ b/src/entities/spots.entity.ts
@@ -6,7 +6,7 @@ import { Location } from './locations.entity';
 @Entity()
 export class Spot extends CommonEntity {
 	@ManyToOne(() => Location, (location: Location) => location.spots, {
-		onDelete: 'CASCADE',
+		onDelete: 'SET NULL',
 	})
 	@JoinColumn([{ name: 'location_id', referencedColumnName: 'id' }])
 	location: Location;


### PR DESCRIPTION
## 개요
Location table & Spot Table Cascade 관계 재설정했습니다.

## 작업사항
- spot entity > onDelete: 'SET NULL' -> location 삭제되면 spot의 locationId는 Null로 변경됨
- location entity > cascade: true -> location에 spot과 같이 추가될 때 spot도 db에 같이 저장됨