### PR TITLE
Feat: Design admin main page UI

### DIFF
--- a/src/public/css/admin-main.css
+++ b/src/public/css/admin-main.css
@@ -72,54 +72,56 @@ a {
 }
 
 .header {
+	position: fixed;
 	width: 100%;
 	background-color: white;
-	text-align: right;
-	padding-top: 15px;
-	padding-bottom: 15px;
-	padding-right: 60px;
+	height: 70px;
 	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+	padding-top: 20px;
 }
 
-.header a {
-	font-size: 24px;
-	font-weight: bolder;
-	color: #4d377b;
-	margin-right: 800px;
-}
-
-.header .material-symbols-outlined {
+.material-symbols-outlined {
+	float: right;
 	font-size: 22px;
 	color: gray;
 	cursor: pointer;
-	margin-left: 18px;
+	text-align: right;
+	margin-right: 30px;
+	margin-top: 5px;
+}
+
+#admin_page {
+	font-size: 24px;
+	font-weight: bolder;
+	color: #4d377b;
+	text-align: left;
+	margin-left: 280px;
+	margin-bottom: 20px;
 }
 
 .material-symbols-outlined:hover {
+	font-size: 25px;
 	color: #4d377b;
 }
 
-.header #person {
-	font-size: 30px;
-	color: gray;
-	cursor: pointer;
-	margin-left: 60px;
-}
-
 .wrap {
+	width: 100%;
 	white-space: nowrap;
 }
 
-.ad_box {
+.box {
 	display: inline-block;
 	overflow: auto;
-	margin-top: 40px;
-	margin-left: 300px;
 	background-color: white;
-	width: 800px;
-	height: 280px;
 	border-radius: 5px;
 	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+.ad_box {
+	margin-top: 100px;
+	margin-left: 300px;
+	width: 800px;
+	height: 280px;
 }
 
 .manage_top {
@@ -134,41 +136,63 @@ a {
 }
 
 .community_box {
-	display: inline-block;
-	overflow: auto;
 	width: 300px;
-	background-color: white;
 	height: 280px;
 	margin-top: 40px;
 	margin-left: 40px;
-	border-radius: 5px;
-	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
 }
 
 .ad_reg_box {
-	display: inline-block;
-	overflow: auto;
-	width: 400px;
-	background-color: white;
+	width: 800px;
 	height: 350px;
 	margin-top: 40px;
-	margin-left: 320px;
+	margin-left: 300px;
 	margin-bottom: 40px;
-	border-radius: 5px;
-	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
 }
 
-.ad_edit_box {
+.box_wrap {
 	display: inline-block;
-	overflow: auto;
-	margin-top: 40px;
+	width: 250px;
+	height: 280px;
 	margin-left: 40px;
-	margin-bottom: 40px;
+	margin-bottom: 130px;
+}
+
+.box_wrap .numbers {
+	float: left;
 	background-color: white;
-	width: 650px;
-	height: 350px;
+	margin-top: 40px;
+	width: 100%;
+	height: 120px;
+	border-left: 6px solid #4d377b;
 	border-radius: 5px;
 	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+	text-align: left;
+}
+
+.numbers p {
+	margin-top: 25px;
+	margin-left: 20px;
+	margin-bottom: 10px;
+	font-size: 12px;
+	font-weight: 600;
+	text-align: left;
+	color: gray;
+}
+
+.numbers a {
+	margin-left: 20px;
+	font-size: 36px;
+	font-weight: 800;
+	text-align: center;
+	color: #4d377b;
+}
+
+#ascent p {
+	margin-left: 5px;
+	display: inline;
+	font-size: 8px;
+	color: 007200;
 }
 
 table {
@@ -176,7 +200,6 @@ table {
 	font-weight: bold;
 	text-align: left;
 	border-collapse: collapse;
-	overflow: auto;
 }
 
 th {

--- a/src/public/css/admin-main.css
+++ b/src/public/css/admin-main.css
@@ -1,0 +1,209 @@
+* {
+	box-sizing: border-box;
+	font-family: 'Nanum Gothic', sans-serif;
+}
+
+body {
+	margin: 0;
+	background-color: #f2f2f2;
+	overflow: auto;
+}
+
+.home {
+	text-align: center;
+	background: #4d377b;
+	color: #fff;
+	padding-top: 25px;
+	padding-bottom: 25px;
+	font-size: 16px;
+	font-weight: 600;
+	border-bottom: 2px solid white;
+}
+
+ul,
+li {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+a {
+	text-decoration: none;
+}
+
+.container {
+	position: fixed;
+	width: 260px;
+	background: white;
+	height: 100%;
+	overflow: auto;
+	box-shadow: 0 5px 10px rgba(35, 0, 77, 0.2);
+}
+#menu li a {
+	position: relative;
+	display: block;
+	height: 50px;
+	line-height: 50px;
+	border-bottom: 1px solid #eee;
+	text-align: left;
+	font-size: 14px;
+	font-weight: bold;
+	color: #5f5f5f;
+	padding-left: 10px;
+}
+
+#menu li a:hover {
+	background-color: rgba(198, 128, 255, 0.2);
+	color: #4d377b;
+	border-radius: 5px;
+}
+
+#menu .sub_menu {
+	display: none;
+}
+#menu .sub_menu a {
+	background-color: rgba(204, 204, 204, 0.2);
+	color: #5f5f5f;
+	font-size: 12px;
+}
+#menu .sub_menu a:hover {
+	background-color: rgba(198, 128, 255, 0.4);
+	color: #4d377b;
+}
+
+.header {
+	width: 100%;
+	background-color: white;
+	text-align: right;
+	padding-top: 15px;
+	padding-bottom: 15px;
+	padding-right: 60px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+.header a {
+	font-size: 24px;
+	font-weight: bolder;
+	color: #4d377b;
+	margin-right: 800px;
+}
+
+.header .material-symbols-outlined {
+	font-size: 22px;
+	color: gray;
+	cursor: pointer;
+	margin-left: 18px;
+}
+
+.material-symbols-outlined:hover {
+	color: #4d377b;
+}
+
+.header #person {
+	font-size: 30px;
+	color: gray;
+	cursor: pointer;
+	margin-left: 60px;
+}
+
+.wrap {
+	white-space: nowrap;
+}
+
+.ad_box {
+	display: inline-block;
+	overflow: auto;
+	margin-top: 40px;
+	margin-left: 300px;
+	background-color: white;
+	width: 800px;
+	height: 280px;
+	border-radius: 5px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+.manage_top {
+	background-color: #4d377b;
+	color: white;
+	width: 100%;
+	padding: 16px;
+	font-size: 14px;
+	font-weight: 600;
+	border-top-left-radius: 5px;
+	border-top-right-radius: 5px;
+}
+
+.community_box {
+	display: inline-block;
+	overflow: auto;
+	width: 300px;
+	background-color: white;
+	height: 280px;
+	margin-top: 40px;
+	margin-left: 40px;
+	border-radius: 5px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+.ad_reg_box {
+	display: inline-block;
+	overflow: auto;
+	width: 400px;
+	background-color: white;
+	height: 350px;
+	margin-top: 40px;
+	margin-left: 320px;
+	margin-bottom: 40px;
+	border-radius: 5px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+.ad_edit_box {
+	display: inline-block;
+	overflow: auto;
+	margin-top: 40px;
+	margin-left: 40px;
+	margin-bottom: 40px;
+	background-color: white;
+	width: 650px;
+	height: 350px;
+	border-radius: 5px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+}
+
+table {
+	width: 100%;
+	font-weight: bold;
+	text-align: left;
+	border-collapse: collapse;
+	overflow: auto;
+}
+
+th {
+	background-color: #f2f2f2;
+	font-size: 10px;
+	padding: 15px 10px;
+}
+
+td {
+	font-size: 9px;
+	padding: 10px;
+}
+
+.btn {
+	cursor: pointer;
+	border: none;
+	display: inline-block;
+	border-radius: 3px;
+	border: 1px solid #4d377b;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+	font-size: 9px;
+	font-weight: 600;
+	padding: 4px 8px;
+}
+
+.btn:hover {
+	border: none;
+	background-color: #4d377b;
+	color: white;
+}

--- a/src/public/js/admin-main.js
+++ b/src/public/js/admin-main.js
@@ -1,0 +1,10 @@
+$(document).ready(function () {
+	$('.main_menu').click(function () {
+		$('.sub_menu').slideUp();
+		if ($(this).children('.sub_menu').is(':hidden')) {
+			$(this).children('.sub_menu').slideDown();
+		} else {
+			$(this).children('.sub_menu').slideUp();
+		}
+	});
+});

--- a/src/views/admin-main.hbs
+++ b/src/views/admin-main.hbs
@@ -13,6 +13,17 @@
 		/>
 	</head>
 	<body>
+
+		<div class='header'>
+			<div id='admin_page'>
+				<a>ADMIN PAGE</a>
+				<div class='material-symbols-outlined'>
+					logout
+				</div>
+			</div>
+
+		</div>
+
 		<div class='container'>
 			<div class='home'>
 				지금, 여기
@@ -22,8 +33,7 @@
 					<a href='#'>광고 관리</a>
 					<ul class='sub_menu'>
 						<li><a href='#'>요청 광고 확인</a></li>
-						<li><a href='#'>광고 등록</a></li>
-						<li><a href='#'>광고 수정</a></li>
+						<li><a href='#'>광고 등록 및 수정</a></li>
 					</ul>
 				</li>
 				<li class='main_menu'>
@@ -35,26 +45,10 @@
 			</ul>
 		</div>
 
-		<div class='header'>
-			<a>ADMIN PAGE</a>
-			<span class='material-symbols-outlined'>
-				logout
-			</span>
-			<span class='material-symbols-outlined'>
-				notifications
-			</span>
-			<span class='material-symbols-outlined'>
-				mail
-			</span>
-			<span class='material-symbols-outlined' id='person'>
-				account_circle
-			</span>
-		</div>
-
 		<div class='wrap'>
-			<div class='ad_box'>
+			<div class='ad_box box'>
 				<div class='manage_top'>
-					광고 요청
+					광고 요청 목록
 				</div>
 				<table>
 					<thead>
@@ -88,17 +82,12 @@
 									상세 정보
 								</button></td>
 						</tr>
-						<tr>
-							<td>F</td><td>061-755-1234</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
-									상세 정보
-								</button></td>
-						</tr>
 					</tbody>
 				</table>
 			</div>
-			<div class='community_box'>
+			<div class='community_box box'>
 				<div class='manage_top'>
-					신고 내역
+					신고 내역 목록
 				</div>
 				<table>
 					<thead>
@@ -138,95 +127,94 @@
 		</div>
 
 		<div class='wrap'>
-			<div class='ad_reg_box'>
+			<div class='ad_reg_box box'>
 				<div class='manage_top'>
-					광고 등록
+					광고 및 수정 목록
 				</div>
 				<table>
 					<thead>
 						<tr>
-							<th>NUM</th><th>STATUS</th><th>REGISTER</th>
+							<th>NAME</th><th>TELL</th><th>STATUS</th><th>REGISTER</th><th>MANAGEMENT</th>
 						</tr>
 					</thead>
 					<tbody>
 						<tr>
-							<td>1</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>A</td><td>02-123-4567</td><td>APPROVE</td><td>REGISTER</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 						<tr>
-							<td>2</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>B</td><td>031-452-9512</td><td>APPROVE</td><td>NOT REGISTER</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 						<tr>
-							<td>3</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>C</td><td>032-564-1231</td><td>APPROVE</td><td>NOT REGISTER</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 						<tr>
-							<td>4</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>D</td><td>02-461-8456</td><td>APPROVE</td><td>DELETE</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 						<tr>
-							<td>5</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>E</td><td>031-156-7865</td><td>APPROVE</td><td>REGISTER</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 						<tr>
-							<td>6</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
-									상세 정보
+							<td>F</td><td>032-654-1234</td><td>APPROVE</td><td>REGISTER</td><td><button
+									class='btn'
+									type='button'
+								>
+									광고 관리
 								</button></td>
 						</tr>
 					</tbody>
 				</table>
 			</div>
 
-			<div class='ad_edit_box'>
-				<div class='manage_top'>
-					광고 수정
+			<div class='box_wrap'>
+				<div class='numbers'>
+					{{! <span class='material-symbols-outlined'>
+						person_filled
+					</span> }}
+					<p>TOTAL USERS</p>
+					<a>13,256</a>
+					<span id='ascent'>
+						<p>(+14.2%)</p>
+					</span>
+
 				</div>
-				<table>
-					<thead>
-						<tr>
-							<th>NAME</th><th>TELL</th><th>REGISTER</th><th>EDIT</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>A</td><td>02-123-4567</td><td>REGISTER</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-						<tr>
-							<td>2</td><td>031-452-9512</td><td>REGISTER</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-						<tr>
-							<td>3</td><td>032-564-1231</td><td>REGISTER</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-						<tr>
-							<td>4</td><td>02-461-8456</td><td>DELETE</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-						<tr>
-							<td>5</td><td>031-156-7865</td><td>REGISTER</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-						<tr>
-							<td>6</td><td>032-654-1234</td><td>REGISTER</td><td><button class='btn' type='button'>
-									광고 수정
-								</button></td>
-						</tr>
-					</tbody>
-				</table>
+				<div class='numbers'>
+					{{! <span class='material-symbols-outlined'>
+						list_alt
+					</span> }}
+					<p>TOTAL ADVERTISEMENT</p>
+					<a>256</a>
+					<span id='ascent'>
+						<p>(+27.2%)</p>
+					</span>
+
+				</div>
 			</div>
+
 		</div>
 	</body>
 </html>

--- a/src/views/admin-main.hbs
+++ b/src/views/admin-main.hbs
@@ -1,0 +1,232 @@
+<html>
+	<head>
+		<meta charset='utf-8' />
+		<link rel='stylesheet' href='/css/admin-main.css' />
+		<script src='/lib/jquery-3.6.1.min.js'></script>
+		<script src='/js/admin-main.js'></script>
+		<link rel='preconnect' href='https://fonts.googleapis.com' />
+		<link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+		<link href='https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap' rel='stylesheet' />
+		<link
+			rel='stylesheet'
+			href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0'
+		/>
+	</head>
+	<body>
+		<div class='container'>
+			<div class='home'>
+				지금, 여기
+			</div>
+			<ul id='menu'>
+				<li class='main_menu'>
+					<a href='#'>광고 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='#'>요청 광고 확인</a></li>
+						<li><a href='#'>광고 등록</a></li>
+						<li><a href='#'>광고 수정</a></li>
+					</ul>
+				</li>
+				<li class='main_menu'>
+					<a href='#'>커뮤니티 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='#'>신고 내역</a></li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+
+		<div class='header'>
+			<a>ADMIN PAGE</a>
+			<span class='material-symbols-outlined'>
+				logout
+			</span>
+			<span class='material-symbols-outlined'>
+				notifications
+			</span>
+			<span class='material-symbols-outlined'>
+				mail
+			</span>
+			<span class='material-symbols-outlined' id='person'>
+				account_circle
+			</span>
+		</div>
+
+		<div class='wrap'>
+			<div class='ad_box'>
+				<div class='manage_top'>
+					광고 요청
+				</div>
+				<table>
+					<thead>
+						<tr>
+							<th>NAME</th><th>TELL</th><th>STATUS</th><th>APPROVE</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>A</td><td>032-123-4567</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>B</td><td>070-567-9845</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>C</td><td>031-4931</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>D</td><td>062-124-4623</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>E</td><td>043-453-9948</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>F</td><td>061-755-1234</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<div class='community_box'>
+				<div class='manage_top'>
+					신고 내역
+				</div>
+				<table>
+					<thead>
+						<tr>
+							<th>ID</th><th>CONFIRM</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>kkk1234</td><td><button class='btn' type='button'>
+									내용 확인
+								</button></td>
+						</tr>
+						<tr>
+							<td>asdfg9999</td><td><button class='btn' type='button'>
+									내용 확인
+								</button></td>
+						</tr>
+						<tr>
+							<td>qawsed1234</td><td><button class='btn' type='button'>
+									내용 확인
+								</button></td>
+						</tr>
+						<tr>
+							<td>zxcvd88</td><td><button class='btn' type='button'>
+									내용 확인
+								</button></td>
+						</tr>
+						<tr>
+							<td>adfazdd12</td><td><button class='btn' type='button'>
+									내용 확인
+								</button></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<div class='wrap'>
+			<div class='ad_reg_box'>
+				<div class='manage_top'>
+					광고 등록
+				</div>
+				<table>
+					<thead>
+						<tr>
+							<th>NUM</th><th>STATUS</th><th>REGISTER</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>1</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>2</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>3</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>4</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>5</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+						<tr>
+							<td>6</td><td>NOT REGISTER</td><td><button class='btn' type='button'>
+									상세 정보
+								</button></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<div class='ad_edit_box'>
+				<div class='manage_top'>
+					광고 수정
+				</div>
+				<table>
+					<thead>
+						<tr>
+							<th>NAME</th><th>TELL</th><th>REGISTER</th><th>EDIT</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>A</td><td>02-123-4567</td><td>REGISTER</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+						<tr>
+							<td>2</td><td>031-452-9512</td><td>REGISTER</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+						<tr>
+							<td>3</td><td>032-564-1231</td><td>REGISTER</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+						<tr>
+							<td>4</td><td>02-461-8456</td><td>DELETE</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+						<tr>
+							<td>5</td><td>031-156-7865</td><td>REGISTER</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+						<tr>
+							<td>6</td><td>032-654-1234</td><td>REGISTER</td><td><button class='btn' type='button'>
+									광고 수정
+								</button></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</body>
+</html>

--- a/src/views/view.controller.ts
+++ b/src/views/view.controller.ts
@@ -2,9 +2,15 @@ import { Controller, Get, Render } from '@nestjs/common';
 
 @Controller('view')
 export class ViewController {
-	@Get('/admin')
+	@Get('/admin/login')
 	@Render('admin-login')
-	root() {
+	adminLogin() {
+		return {};
+	}
+
+	@Get('/admin')
+	@Render('admin-main')
+	adminMain() {
 		return {};
 	}
 }


### PR DESCRIPTION
> ### 작업 개요
> 관리자 메인 페이지의 전체적인 UI를 디자인하였습니다.
>> ### 기능
>> * 기본 UI 디자인
>> * 좌측 아코디언 스타일 메뉴 구현
>> * 버튼, 메뉴 hover 시 색상 변경
>> * 메인의 표 부분은 5~6개 정도만 보이도록 할 예정이고 메인 페이지에서 바로 승인하는 게 아닌 페이지로 이동하게 할 예정입니다.
>> * 데이터 부분은 어떤 형식으로 보일 지 나타내기 위해서 임의로 넣었습니다.
>> ### 차후 추가 될 기능
>> * 좌측 서브 메뉴와 메인 페이지의 버튼 클릭 시 광고 관리, 신고 관리 페이지로 이동
>> * 로그인 후 해당 메인 페이지 나타날 수 있도록 구현 예정
>> * 색상이나 세부 디자인 등은 유동적으로 변할 수도 있습니다.
>> * 괜찮은 아이콘을 못찾아서... 아이콘 찾으면 우측 하단 유저와 광고 부분에 아이콘이 삽입될 수 있습니다.
>> ### 테스트
>> * 서버 실행 후, localhost:3000/view/admin 이동 후 해당 페이지가 잘 나타나는지 테스트 부탁드립니다.
>> * 상기한 기능이 정상 동작하는지 테스트 부탁드립니다.
>> ### UI 디자인 사진 첨부
>>  ![admin-main](https://user-images.githubusercontent.com/108920053/200636961-a2f55046-0be0-4417-81ec-da5577e44f7e.png)