### PR TITLE
Feat: Ncloud S3 api (ad-forms license image)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@nestjs/typeorm": "^9.0.1",
 		"@types/jsonwebtoken": "^8.5.9",
 		"@types/passport-facebook": "^2.1.11",
+		"aws-sdk": "^2.1248.0",
 		"bcrypt": "^5.0.1",
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.13.2",
@@ -44,6 +45,8 @@
 		"hbs": "^4.2.0",
 		"joi": "^17.6.1",
 		"jsonwebtoken": "^8.5.1",
+		"multer": "^1.4.5-lts.1",
+		"multer-s3": "^3.0.1",
 		"passport": "^0.6.0",
 		"passport-facebook": "^3.0.0",
 		"passport-jwt": "^4.0.0",
@@ -55,7 +58,8 @@
 		"swagger-ui-express": "^4.5.0",
 		"typeorm": "^0.3.9",
 		"typeorm-naming-strategies": "^4.1.0",
-		"typeorm-seeding": "^1.6.1"
+		"typeorm-seeding": "^1.6.1",
+		"uuidv4": "^6.2.13"
 	},
 	"devDependencies": {
 		"@nestjs/cli": "^9.0.0",

--- a/src/config/config.constant.ts
+++ b/src/config/config.constant.ts
@@ -45,6 +45,13 @@ export type EmailConfig = {
 	emailPassword: string;
 };
 
+export type NcloudConfig = {
+	accessKeyId: string;
+	secretAccessKey: string;
+	storageEndPoint: string;
+	storageBucket: string;
+};
+
 export const appConfig = (): { appConfig: AppConfig } => ({
 	appConfig: {
 		env: process.env.NODE_ENV as NodeEnv,
@@ -93,5 +100,14 @@ export const emailConfig = (): { emailConfig: EmailConfig } => ({
 	emailConfig: {
 		email: process.env.EMAIL,
 		emailPassword: process.env.EMAIL_PASSWORD,
+	},
+});
+
+export const ncloudConfig = (): { ncloudConfig: NcloudConfig } => ({
+	ncloudConfig: {
+		accessKeyId: process.env.NCLOUD_ACCESS_KEY_ID,
+		secretAccessKey: process.env.NCLOUD_SECRET_ACCESS_KEY,
+		storageEndPoint: process.env.NCLOUD_STORAGE_ENDPOINT,
+		storageBucket: process.env.NCLOUD_STORAGE_BUCKET,
 	},
 });

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule as NestConfigModule } from '@nestjs/config';
 
-import { appConfig, databaseConfig, emailConfig, jwtConfig, oauthConfig } from './config.constant';
+import { appConfig, databaseConfig, emailConfig, jwtConfig, ncloudConfig, oauthConfig } from './config.constant';
 import { configValidationSchema } from './config.validation';
 
 @Module({
@@ -9,7 +9,7 @@ import { configValidationSchema } from './config.validation';
 		NestConfigModule.forRoot({
 			isGlobal: true,
 			envFilePath: [`.env.${process.env.STAGE}`],
-			load: [appConfig, databaseConfig, oauthConfig, jwtConfig, emailConfig],
+			load: [appConfig, databaseConfig, oauthConfig, jwtConfig, emailConfig, ncloudConfig],
 			validationSchema: configValidationSchema,
 		}),
 	],

--- a/src/config/config.validation.ts
+++ b/src/config/config.validation.ts
@@ -20,4 +20,8 @@ export const configValidationSchema = Joi.object({
 	JWT_REFRESH_TOKEN_EXPIRATION_TIME: Joi.string().required(),
 	EMAIL: Joi.string().required(),
 	EMAIL_PASSWORD: Joi.string().required(),
+	NCLOUD_ACCESS_KEY_ID: Joi.string().required(),
+	NCLOUD_SECRET_ACCESS_KEY: Joi.string().required(),
+	NCLOUD_STORAGE_ENDPOINT: Joi.string().required(),
+	NCLOUD_STORAGE_BUCKET: Joi.string().required(),
 });

--- a/src/modules/ad-forms/ad-forms.controller.spec.ts
+++ b/src/modules/ad-forms/ad-forms.controller.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -19,6 +20,17 @@ describe('AdFormsController', () => {
 				{
 					provide: getRepositoryToken(AdForm),
 					useClass: MockAdFormsRepository,
+				},
+				{
+					provide: ConfigService,
+					useValue: {
+						get: jest.fn((key: string) => {
+							if (key === 'ncloudConfig') {
+								return 1;
+							}
+							return null;
+						}),
+					},
 				},
 			],
 		}).compile();

--- a/src/modules/ad-forms/ad-forms.service.spec.ts
+++ b/src/modules/ad-forms/ad-forms.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AdForm } from 'src/entities/ad-form.entity';
@@ -15,6 +16,17 @@ describe('AdFormsService', () => {
 				{
 					provide: getRepositoryToken(AdForm),
 					useClass: MockAdFormsRepository,
+				},
+				{
+					provide: ConfigService,
+					useValue: {
+						get: jest.fn((key: string) => {
+							if (key === 'ncloudConfig') {
+								return 1;
+							}
+							return null;
+						}),
+					},
 				},
 			],
 		}).compile();


### PR DESCRIPTION
## 개요
이미지 파일 저장을 위해 NCloud Object Storage를 사용했습니다.
api를 연동하여 bucket에 이미지 파일이 정상적으로 들어가게 했습니다.
## 작업사항
- adForms/service.ts : Ncloud 연동 및 파일 업로드
- env 파일 업데이트 : Ncloud 관련 키 추가 (따로 슬랙에 공지하겠습니다)
## Ncloud object storage 폴더 구조
```bash
── bucket
    ├── licences (광고 요청때 사업자등록증)
    │   └── ...png
    │   └── ...png
    ├── sns-posts (인스타그램 사진 - 아직 생성X)
    │   └── ...png
    │   └── ...png
    └── ...
``` 
## 테스트 요청
- POST /ad-forms 로 요청 보냈을 때,
  - 사진이 정상적으로 s3에 들어갔는지
  - DB에 저장된 사진 url로 들어갔을 때 사진이 잘 보이는지
 테스트 부탁드려요
- 저는 Postman의 form-data로 테스트 했습니다.