### PR TITLE
Feat: Link API calls from UI in admin login

### DIFF
--- a/src/public/css/admin-login.css
+++ b/src/public/css/admin-login.css
@@ -54,6 +54,7 @@ h1 {
 	margin-top: 16px;
 	margin-bottom: 18px;
 	border-radius: 5px;
+	cursor: pointer;
 }
 
 .submit_btn:hover {

--- a/src/public/js/admin-login.js
+++ b/src/public/js/admin-login.js
@@ -6,17 +6,33 @@ $(document).ready(function () {
 
 		if (param.email == '') {
 			alert('아이디를 입력해주세요.');
+			return false;
 		} else if (param.password == '') {
 			alert('비밀번호를 입력해주세요.');
+			return false;
 		}
 
-		// $.ajax({
-		// 	url:
-		// 	data: param,
-		// 	type: 'POST',
-		// 	dataType: 'JSON',
-		// });
-
-		//TODO : 통신처리
+		$.ajax({
+			url: '/auth/login',
+			data: param,
+			type: 'POST',
+			dataType: 'JSON',
+			success: function (data) {
+				if (data.user.type == 'Admin') {
+					localStorage.setItem('accessToken', data.accessToken);
+					localStorage.setItem('refreshToken', data.refreshToken);
+					console.log(localStorage.getItem('accessToken')); //토큰 저장 확인 (삭제 예정)
+					console.log(localStorage.getItem('refreshToken')); //토큰 저장 확인 (삭제 예정)
+					alert('로그인 성공!');
+					window.location.href = 'http://localhost:3000/view/admin';
+				} else {
+					alert('관리자 계정으로 로그인해주세요.');
+				}
+			},
+			error: function (data) {
+				alert('이메일 혹은 비밀번호를 다시 한 번 확인해주세요.');
+				return false;
+			},
+		});
 	});
 });

--- a/src/public/js/admin-main.js
+++ b/src/public/js/admin-main.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+	console.log(localStorage.getItem('accessToken')); //토큰 저장 확인(삭제 예정)
+	console.log(localStorage.getItem('refreshToken')); //토큰 저장 확인(삭제 예정)
 	$('.main_menu').click(function () {
 		$('.sub_menu').slideUp();
 		if ($(this).children('.sub_menu').is(':hidden')) {

--- a/src/views/admin-login.hbs
+++ b/src/views/admin-login.hbs
@@ -15,7 +15,7 @@
 					<h1>ADMIN LOGIN</h1>
 					<input type='text' name='email' class='text_field' id='email' placeholder='email' />
 					<input type='password' name='password' class='text_field' id='password' placeholder='password' />
-					<input type='submit' id='login' value='로그인' class='submit_btn' />
+					<button id='login' class='submit_btn' type='button'>로그인</button>
 				</form>
 			</center>
 		</div>

--- a/src/views/view.controller.ts
+++ b/src/views/view.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Render } from '@nestjs/common';
+import { Controller, Get, Render, Res } from '@nestjs/common';
+import { Response } from 'express';
 
 @Controller('view')
 export class ViewController {
 	@Get('/admin/login')
-	@Render('admin-login')
-	adminLogin() {
-		return {};
+	adminLogin(@Res() res: Response) {
+		return res.render('admin-login');
 	}
 
 	@Get('/admin')


### PR DESCRIPTION
> ### 작업 개요
> 관리자 로그인 UI는 더 수정이 없을 것 같아 API 연동하였습니다.
>> ### 기능
>> * 로그인 API 호출
>> * 토큰 저장
>> * admin 계정만 로그인 할 수 있도록 설정
>> * 로그인 성공 후 관리자 메인 페이지로 이동
>> ### 테스트
>> * 서버 실행 후 localhost:3000/admin/login에 접속하신 후 관리자 시드 데이터 계정과 비밀번호로 로그인하시고 정상적으로 로그인되는 지 확인 부탁드립니다.
>> * 로그인 후 저장된 토큰이 console 창에 나타나는지 확인 부탁드립니다. (확인 후 관련 코드 삭제 예정)
>> * 올바르지 않은 이메일/비밀번호 입력 시 로그인 실패 창이 뜨는지 확인 부탁드립니다.
>> * 관리자 계정이 아닌 다른 타입의 계정이 있으시다면 해당 계정으로 로그인하시고 관리자 계정으로 로그인 하라는 경고 알림 창이 뜨는지 확인 부탁드립니다.
>> ### 차후 추가될 기능
>> * 관리자만 사용 가능한 페이지는 관리자 로그인한 사용자만 사용할 수 있도록 할 예정입니다. 현재는 개발 시 불편할 것 같아 아직 구현하지 않았습니다.
>> * 로그아웃 기능