### PR TITLE
Feat: Design admin ad request table UI

### DIFF
--- a/src/public/css/ad-request.css
+++ b/src/public/css/ad-request.css
@@ -12,8 +12,11 @@ body {
 .home {
 	text-align: center;
 	background: #4d377b;
+	color: #fff;
 	padding-top: 25px;
 	padding-bottom: 25px;
+	font-size: 16px;
+	font-weight: 600;
 	border-bottom: 2px solid white;
 }
 
@@ -107,129 +110,130 @@ a {
 	color: #4d377b;
 }
 
-.wrap {
-	width: 100%;
-	white-space: nowrap;
-}
-
-.box {
-	display: inline-block;
-	overflow: auto;
-	background-color: white;
-	border-radius: 5px;
-	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
-}
-
-.ad_box {
-	margin-top: 100px;
-	margin-left: 300px;
-	width: 800px;
-	height: 280px;
-}
-
-.manage_top {
-	background-color: #4d377b;
-	color: white;
-	width: 100%;
-	padding: 16px;
-	font-size: 14px;
-	font-weight: 600;
-	border-top-left-radius: 5px;
-	border-top-right-radius: 5px;
-}
-
-.community_box {
-	width: 300px;
-	height: 280px;
-	margin-top: 40px;
-	margin-left: 40px;
-}
-
-.ad_reg_box {
-	width: 800px;
-	height: 350px;
-	margin-top: 40px;
-	margin-left: 300px;
-	margin-bottom: 40px;
-}
-
-.box_wrap {
-	display: inline-block;
-	width: 250px;
-	height: 280px;
-	margin-left: 40px;
-	margin-bottom: 130px;
-}
-
-.box_wrap .numbers {
-	float: left;
-	background-color: white;
-	margin-top: 40px;
-	width: 100%;
-	height: 120px;
-	border-left: 6px solid #4d377b;
-	border-radius: 5px;
-	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
-	text-align: left;
-}
-
-.numbers p {
-	margin-top: 25px;
-	margin-left: 20px;
-	margin-bottom: 10px;
+input {
+	height: 28px;
 	font-size: 12px;
-	font-weight: 600;
-	text-align: left;
-	color: gray;
+	border: 0;
+	border-radius: 5px;
+	outline: none;
+	background-color: white;
 }
 
-.numbers a {
-	margin-left: 20px;
-	font-size: 36px;
-	font-weight: 800;
-	text-align: center;
+.ad_request {
+	padding-top: 100px;
+	padding-left: 350px;
+}
+
+.ad_request a {
+	font-size: 18px;
+	font-weight: 600;
 	color: #4d377b;
 }
 
-#ascent p {
-	margin-left: 5px;
-	display: inline;
-	font-size: 8px;
-	color: 007200;
+#append_table {
+	margin-top: 20px;
+	margin-bottom: 50px;
 }
 
-table {
-	width: 100%;
-	font-weight: bold;
-	text-align: left;
-	border-collapse: collapse;
-}
-
-th {
-	background-color: #f2f2f2;
-	font-size: 10px;
-	padding: 15px 10px;
-}
-
-td {
-	font-size: 9px;
-	padding: 10px;
-}
-
-.btn {
-	cursor: pointer;
-	border: none;
-	display: inline-block;
-	border-radius: 3px;
-	border: 1px solid #4d377b;
-	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
-	font-size: 9px;
+#append_table th {
+	padding-top: 5px;
+	font-size: 14px;
 	font-weight: 600;
-	padding: 4px 8px;
 }
 
-.btn:hover {
-	border: none;
+#append_table td {
+	padding: 10px 20px;
+	font-size: 10px;
+}
+
+#append_row {
+	font-size: 12px;
+	font-weight: 800;
+	height: 28px;
+	outline: none;
+	border: #4d377b solid 2px;
+	cursor: pointer;
+	border-radius: 5px;
+	background-color: white;
+}
+
+#append_row:hover {
+	background-color: #ebe7f1;
+}
+
+#list_table {
+	width: 1000px;
+	border-radius: 8px;
+	border-collapse: collapse;
+	margin-top: 10px;
+	margin-bottom: 50px;
+	text-align: center;
+}
+
+#list_table tr {
+	border-top: #d3d3d3 solid 1px;
+}
+
+#list_table tr:nth-child(odd) {
+	background-color: white;
+}
+
+#list_table tr:nth-child(even) {
+	background-color: #ebe7f1;
+}
+
+#list_table th,
+td {
+	padding: 15px 30px;
+}
+
+#list_table th {
 	background-color: #4d377b;
 	color: white;
+	font-size: 14px;
+	font-weight: 700;
+}
+
+#list_table td {
+	font-size: 12px;
+	color: black;
+	font-weight: 600;
+}
+
+#list_table .detail-link,
+#list_table .delete-link {
+	font-size: 14px;
+	color: #4d377b;
+	font-weight: bold;
+}
+
+#popup {
+	display: none;
+	width: 500px;
+	height: 500px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	margin: -250px 0 0 -250px;
+	background-color: #fff;
+	z-index: 2;
+	border-radius: 10px;
+}
+
+.backon {
+	content: '';
+	width: 100%;
+	height: 100%;
+	background: #00000054;
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 1;
+}
+
+.close {
+	position: absolute;
+	top: -25px;
+	right: 0;
+	cursor: pointer;
 }

--- a/src/public/js/ad-request.js
+++ b/src/public/js/ad-request.js
@@ -15,6 +15,7 @@ $(document).ready(function () {
 				$('<td>').append($('#add_id').val()),
 				$('<td>').append($('#add_business').val()),
 				$('<td>').append($('#add_email').val()),
+				$('<td>').append($('#add_date').val()),
 				$('<td>').append($('#add_status').val()),
 				$('<td>').append($('<a>').prop('href', '#').addClass('detail-link').append('DETAIL')),
 				$('<td>').append($('<a>').prop('href', '#').addClass('delete-link').append('DELETE')),

--- a/src/public/js/ad-request.js
+++ b/src/public/js/ad-request.js
@@ -1,0 +1,40 @@
+$(document).ready(function () {
+	$('.main_menu').click(function () {
+		$('.sub_menu').slideUp();
+		if ($(this).children('.sub_menu').is(':hidden')) {
+			$(this).children('.sub_menu').slideDown();
+		} else {
+			$(this).children('.sub_menu').slideUp();
+		}
+	});
+
+	$('#append_row').on('click', function () {
+		$('#list_table').append(
+			$('<tr>').append(
+				$('<td>').append($('#add_no').val()),
+				$('<td>').append($('#add_id').val()),
+				$('<td>').append($('#add_business').val()),
+				$('<td>').append($('#add_email').val()),
+				$('<td>').append($('#add_status').val()),
+				$('<td>').append($('<a>').prop('href', '#').addClass('detail-link').append('DETAIL')),
+				$('<td>').append($('<a>').prop('href', '#').addClass('delete-link').append('DELETE')),
+			),
+		);
+	});
+
+	$('#list_table').on('click', '.delete-link', function () {
+		$(this).parent().parent().remove();
+	});
+
+	$('#list_table').on('click', '.detail-link', function (event) {
+		$('#popup').show();
+		$('body').append('<div class="backon"></div>');
+	});
+
+	$('body').on('click', function (event) {
+		if (event.target.className == 'close' || event.target.className == 'backon') {
+			$('#popup').hide();
+			$('.backon').hide();
+		}
+	});
+});

--- a/src/views/ad-request.hbs
+++ b/src/views/ad-request.hbs
@@ -1,0 +1,124 @@
+<html>
+	<head>
+		<meta charset='utf-8' />
+		<link rel='stylesheet' href='/css/ad-request.css' />
+		<script src='/lib/jquery-3.6.1.min.js'></script>
+		<script src='/js/ad-request.js'></script>
+		<link rel='preconnect' href='https://fonts.googleapis.com' />
+		<link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+		<link href='https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap' rel='stylesheet' />
+		<link
+			rel='stylesheet'
+			href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0'
+		/>
+	</head>
+	<body>
+
+		<div class='header'>
+			<div id='admin_page'>
+				<a>ADMIN PAGE</a>
+				<div class='material-symbols-outlined'>
+					logout
+				</div>
+			</div>
+
+		</div>
+
+		<div class='container'>
+			<div class='home'>
+				<a href='http://localhost:3000/view/admin'> 지금, 여기 </a>
+			</div>
+			<ul id='menu'>
+				<li class='main_menu'>
+					<a href='#'>광고 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='http://localhost:3000/view/admin/ad-request'>요청 광고 확인</a></li>
+						<li><a href='#'>광고 등록 및 수정</a></li>
+					</ul>
+				</li>
+				<li class='main_menu'>
+					<a href='#'>커뮤니티 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='#'>신고 내역</a></li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+
+		<div class='ad_request'>
+			<a>추가 입력</a>
+			<table id='append_table'>
+				<thead>
+					<tr>
+						<th><label for='add_no'>NO</label></th>
+						<th>ID</th>
+						<th>BUSINESS</th>
+						<th>EMAIL</th>
+						<th>STATUS</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><input type='text' id='add_no' /></td>
+						<td><input type='text' id='add_id' /></td>
+						<td><input type='text' id='add_business' /></td>
+						<td><input type='text' id='add_email' /></td>
+						<td><input type='text' id='add_status' /></td>
+						<td><button type='button' id='append_row'>데이터 추가</button></td>
+					</tr>
+				</tbody>
+			</table>
+
+			<table id='list_table'>
+				<thead>
+					<tr>
+						<th>NO</th>
+						<th>ID</th>
+						<th>BUSINESS</th>
+						<th>EMAIL</th>
+						<th>STATUS</th>
+						<th>DETAIL</th>
+						<th>DELETE</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>1</td>
+						<td>kkk1234</td>
+						<td>A</td>
+						<td>kkk1234@gmail.com</td>
+						<td>NOT APPROVE</td>
+						<td>
+							<a href='#' class='detail-link'>DETAIL</a>
+						</td>
+						<td>
+							<a href='#' class='delete-link'>DELETE</a>
+						</td>
+					</tr>
+					<tr>
+						<td>2</td>
+						<td>abc9999</td>
+						<td>B</td>
+						<td>abc9999@gmail.com</td>
+						<td>NOT APPROVE</td>
+						<td>
+							<a href='#' class='detail-link'>DETAIL</a>
+						</td>
+						<td>
+							<a href='#' class='delete-link'>DELETE</a>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div id='popup'>
+			<div class='close'>close</div>
+			<div style='text-align : center; margin-top:70px;'><img
+					src='https://scontent-ssn1-1.xx.fbcdn.net/v/t39.30808-6/273300062_5512099255560765_7231279751257498891_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=973b4a&_nc_ohc=9LgI2Z7Ags0AX_liZ1Z&_nc_ht=scontent-ssn1-1.xx&oh=00_AfBtTFCGHYlM26OBDv6FEjLKTk9_OeW9YdAayUK4GB2Vlg&oe=63766D1C'
+					style='width:70%; height:70%;'
+				/>
+			</div>
+		</div>
+
+	</body>
+</html>

--- a/src/views/ad-request.hbs
+++ b/src/views/ad-request.hbs
@@ -16,7 +16,7 @@
 
 		<div class='header'>
 			<div id='admin_page'>
-				<a>ADMIN PAGE</a>
+				<a>요청 광고 확인</a>
 				<div class='material-symbols-outlined'>
 					logout
 				</div>
@@ -54,6 +54,7 @@
 						<th>ID</th>
 						<th>BUSINESS</th>
 						<th>EMAIL</th>
+						<th>DATE</th>
 						<th>STATUS</th>
 					</tr>
 				</thead>
@@ -63,6 +64,7 @@
 						<td><input type='text' id='add_id' /></td>
 						<td><input type='text' id='add_business' /></td>
 						<td><input type='text' id='add_email' /></td>
+						<td><input type='text' id='add_date' /></td>
 						<td><input type='text' id='add_status' /></td>
 						<td><button type='button' id='append_row'>데이터 추가</button></td>
 					</tr>
@@ -76,6 +78,7 @@
 						<th>ID</th>
 						<th>BUSINESS</th>
 						<th>EMAIL</th>
+						<th>DATE</th>
 						<th>STATUS</th>
 						<th>DETAIL</th>
 						<th>DELETE</th>
@@ -87,6 +90,7 @@
 						<td>kkk1234</td>
 						<td>A</td>
 						<td>kkk1234@gmail.com</td>
+						<td>2022-11-10</td>
 						<td>NOT APPROVE</td>
 						<td>
 							<a href='#' class='detail-link'>DETAIL</a>
@@ -100,6 +104,7 @@
 						<td>abc9999</td>
 						<td>B</td>
 						<td>abc9999@gmail.com</td>
+						<td>2022-11-14</td>
 						<td>NOT APPROVE</td>
 						<td>
 							<a href='#' class='detail-link'>DETAIL</a>

--- a/src/views/admin-main.hbs
+++ b/src/views/admin-main.hbs
@@ -26,13 +26,13 @@
 
 		<div class='container'>
 			<div class='home'>
-				지금, 여기
+				<a href='http://localhost:3000/view/admin'>지금, 여기</a>
 			</div>
 			<ul id='menu'>
 				<li class='main_menu'>
 					<a href='#'>광고 관리</a>
 					<ul class='sub_menu'>
-						<li><a href='#'>요청 광고 확인</a></li>
+						<li><a href='http://localhost:3000/view/admin/ad-request'>요청 광고 확인</a></li>
 						<li><a href='#'>광고 등록 및 수정</a></li>
 					</ul>
 				</li>
@@ -58,27 +58,47 @@
 					</thead>
 					<tbody>
 						<tr>
-							<td>A</td><td>032-123-4567</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+							<td>A</td><td>032-123-4567</td><td>NOT APPROVE</td><td><button
+									class='btn'
+									type='button'
+									onClick="location.href='http://localhost:3000/view/admin/ad-request'"
+								>
 									상세 정보
 								</button></td>
 						</tr>
 						<tr>
-							<td>B</td><td>070-567-9845</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+							<td>B</td><td>070-567-9845</td><td>NOT APPROVE</td><td><button
+									class='btn'
+									type='button'
+									onClick="location.href='http://localhost:3000/view/admin/ad-request'"
+								>
 									상세 정보
 								</button></td>
 						</tr>
 						<tr>
-							<td>C</td><td>031-4931</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+							<td>C</td><td>031-4931</td><td>NOT APPROVE</td><td><button
+									class='btn'
+									type='button'
+									onClick="location.href='http://localhost:3000/view/admin/ad-request'"
+								>
 									상세 정보
 								</button></td>
 						</tr>
 						<tr>
-							<td>D</td><td>062-124-4623</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+							<td>D</td><td>062-124-4623</td><td>NOT APPROVE</td><td><button
+									class='btn'
+									type='button'
+									onClick="location.href='http://localhost:3000/view/admin/ad-request'"
+								>
 									상세 정보
 								</button></td>
 						</tr>
 						<tr>
-							<td>E</td><td>043-453-9948</td><td>NOT APPROVE</td><td><button class='btn' type='button'>
+							<td>E</td><td>043-453-9948</td><td>NOT APPROVE</td><td><button
+									class='btn'
+									type='button'
+									onClick="location.href='http://localhost:3000/view/admin/ad-request'"
+								>
 									상세 정보
 								</button></td>
 						</tr>

--- a/src/views/view.controller.ts
+++ b/src/views/view.controller.ts
@@ -13,4 +13,9 @@ export class ViewController {
 	adminMain() {
 		return {};
 	}
+
+	@Get('/admin/ad-request')
+	adRequestn(@Res() res: Response) {
+		return res.render('ad-request');
+	}
 }


### PR DESCRIPTION
> ### 작업 개요
> * 광고 요청을 확인할 수 있는 목록 테이블의 UI를 디자인하였습니다.
>> ### 기능
>> * 메인 홈에서 광고 관리 -> 요청 광고 확인 클릭 시 해당 페이지로 이동
>> * 좌측 고정 메뉴 상단 '지금, 여기' 글자 클릭 시 메인 페이지로 이동 (홈 메뉴 아이콘 추가 예정)
>> * 광고 요청 확인 가능한 동적 테이블 디자인
>> * 테이블 내용 입력 후 행을 추가할 수 있는 기능 구현 (동적 테이블 확인 및 많은 더미 데이터로 인한 코드 가독성이 저하될 것을 우려하여 임시로 넣은 기능, API link 후 삭제 예정)
>> * 테이블 내 detail 선택 시 모달 팝업 창 오픈 (상세 내용 기재 x), 외부 클릭 시 닫힘
>> * 테이블 내 delete 선택 시 해당 행 삭제
>> ### 구현 예정
>> * 요청 날짜 별, 상태 별 정렬
>> * API 호출 후 정상적인 데이터 받아온 후 페이징 처리
>> * 모달 팝업 내 상세 내용 구현
>> * 테이블의 상세 디자인은 바뀔 수 있습니다
>> ### 테스트
>> * 홈(localhost:3000/view/admin)에서 광고 관리, 요청 광고 확인 메뉴 클릭 시 해당 페이지로 이동 되는지 확인 부탁드립니다.
>> * 좌측 메뉴 상단의 지금 여기 글자 클릭 시 메인 페이지로 이동 되는지 확인 부탁드립니다.
>> * 추가적으로 행의 내용을 입력 후 정상적으로 테이블이 늘어나는지 확인 부탁드립니다.
>> * delete 클릭 후 정상적으로 행의 내용이 삭제되는지 확인 부탁드립니다.
>> * detail 클릭 후 모달 팝업 창이 정상적으로 뜨는지, 팝업 창 외부 클릭 시 팝업이 정상적으로 닫히는 지 확인 부탁드립니다.
>> ### UI 디자인 사진 첨부
>> ![ad-form](https://user-images.githubusercontent.com/108920053/201641142-dd63895d-89b4-4ca6-b3de-f7d8fc2469fe.png)
