### PR TITLE
Feat: Throw Exception code (auth-code, user)

### DIFF
--- a/src/modules/auth-codes/auth-codes.controller.spec.ts
+++ b/src/modules/auth-codes/auth-codes.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthCode } from 'src/entities/auth-code.entity';
+import { User } from 'src/entities/users.entity';
 import { MailerModule } from 'src/mailer/mailer.module';
 import { MockAuthCodesRepository } from 'test/mock/auth-codes.mock';
+import { MockUsersRepository } from 'test/mock/users.mock';
 import { AuthCodesController } from './auth-codes.controller';
 import { AuthCodesService } from './auth-codes.service';
 
@@ -18,6 +20,10 @@ describe('AuthCodesController', () => {
 				{
 					provide: getRepositoryToken(AuthCode),
 					useClass: MockAuthCodesRepository,
+				},
+				{
+					provide: getRepositoryToken(User),
+					useClass: MockUsersRepository,
 				},
 			],
 		}).compile();

--- a/src/modules/auth-codes/auth-codes.module.ts
+++ b/src/modules/auth-codes/auth-codes.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthCode } from 'src/entities/auth-code.entity';
+import { User } from 'src/entities/users.entity';
 import { AuthCodesController } from './auth-codes.controller';
 import { AuthCodesService } from './auth-codes.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([AuthCode])],
+	imports: [TypeOrmModule.forFeature([AuthCode, User])],
 	controllers: [AuthCodesController],
 	providers: [AuthCodesService],
 })

--- a/src/modules/auth-codes/auth-codes.service.spec.ts
+++ b/src/modules/auth-codes/auth-codes.service.spec.ts
@@ -2,7 +2,9 @@ import { MailerService } from '@nestjs-modules/mailer';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthCode } from 'src/entities/auth-code.entity';
+import { User } from 'src/entities/users.entity';
 import { MockAuthCodesRepository } from 'test/mock/auth-codes.mock';
+import { MockUsersRepository } from 'test/mock/users.mock';
 import { AuthCodesService } from './auth-codes.service';
 
 describe('AuthCodesService', () => {
@@ -22,6 +24,10 @@ describe('AuthCodesService', () => {
 				{
 					provide: getRepositoryToken(AuthCode),
 					useClass: MockAuthCodesRepository,
+				},
+				{
+					provide: getRepositoryToken(User),
+					useClass: MockUsersRepository,
 				},
 			],
 		}).compile();

--- a/src/modules/taste-spots/taste-spots.service.ts
+++ b/src/modules/taste-spots/taste-spots.service.ts
@@ -17,6 +17,7 @@ export class TasteSpotsService {
 	) {}
 
 	async getTasteSpots(): Promise<TasteSpotsResponseDto[]> {
+		//TODO: 알고리즘 수정 예정
 		let snsPosts = await this.snsPostsRepository
 			.createQueryBuilder('sns_post')
 			.select('sns_post.theme_id, Max(sns_post.spot_id) as "spot_id"')

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { TasteSpot } from 'src/entities/taste-spots.entity';
 
+import { Spot } from 'src/entities/spots.entity';
+import { TasteSpot } from 'src/entities/taste-spots.entity';
 import { User } from 'src/entities/users.entity';
+import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockTasteSpotsRepository } from 'test/mock/taste-spots.mock';
 import { MockUsersRepository } from 'test/mock/users.mock';
 import { UsersController } from './users.controller';
@@ -23,6 +25,10 @@ describe('UsersController', () => {
 				{
 					provide: getRepositoryToken(TasteSpot),
 					useClass: MockTasteSpotsRepository,
+				},
+				{
+					provide: getRepositoryToken(Spot),
+					useClass: MockSpotsRepository,
 				},
 			],
 		}).compile();

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Spot } from 'src/entities/spots.entity';
 import { TasteSpot } from 'src/entities/taste-spots.entity';
 
 import { User } from 'src/entities/users.entity';
@@ -7,7 +8,7 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([User, TasteSpot])],
+	imports: [TypeOrmModule.forFeature([User, TasteSpot, Spot])],
 	controllers: [UsersController],
 	providers: [UsersService],
 })

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { TasteSpot } from 'src/entities/taste-spots.entity';
 
+import { Spot } from 'src/entities/spots.entity';
+import { TasteSpot } from 'src/entities/taste-spots.entity';
 import { User } from 'src/entities/users.entity';
+import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockTasteSpotsRepository } from 'test/mock/taste-spots.mock';
 import { MockUsersRepository } from 'test/mock/users.mock';
 import { UsersService } from './users.service';
@@ -22,6 +24,10 @@ describe('UsersService', () => {
 				{
 					provide: getRepositoryToken(TasteSpot),
 					useClass: MockTasteSpotsRepository,
+				},
+				{
+					provide: getRepositoryToken(Spot),
+					useClass: MockSpotsRepository,
 				},
 			],
 		}).compile();


### PR DESCRIPTION
- auth-code, user service 파일에 예외처리를 추가했습니다.
  - 회원가입 인증코드를 요청하는 email이 이미 회원의 email이라면 exception
  - 사용자의 여행지 취향을 post할 때, tasteSpots 배열 속 spotId 중 존재하지 않는 spotId가 있다면 exception