### PR TITLE
Feat: Find & Change user's password API

### DIFF
--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -32,7 +32,7 @@ export class User extends CommonEntity {
 	type: UserType;
 
 	@IsString()
-	@Length(2, 10)
+	@Length(8, 24)
 	@Column({ type: 'varchar', nullable: true }) //TODO: strong pw
 	password: string;
 

--- a/src/modules/auth-codes/auth-codes.controller.ts
+++ b/src/modules/auth-codes/auth-codes.controller.ts
@@ -21,4 +21,9 @@ export class AuthCodesController {
 	async verifyAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
 		return await this.authCodesService.verifyAuthCode(authCode);
 	}
+
+	@Post('/find-pw')
+	async findUsersPw(@Body() authCodeReq: AuthCodeRequestDto) {
+		return await this.authCodesService.generateFindPwAuthCode(authCodeReq.email);
+	}
 }

--- a/src/modules/auth-codes/auth-codes.controller.ts
+++ b/src/modules/auth-codes/auth-codes.controller.ts
@@ -18,17 +18,19 @@ export class AuthCodesController {
 	}
 
 	@Post('/signup/verify')
-	@ApiDocs.verifySignUpAuthCode('회원가입 인증 코드 확인')
+	@ApiDocs.verifySignUpAuthCode('회원가입을 위한 인증 코드 확인')
 	async verifySignUpAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
 		return await this.authCodesService.verifyAuthCode(authCode, AuthCodeType.SignUp);
 	}
 
 	@Post('/find-pw')
-	async findUsersPw(@Body() authCodeReq: AuthCodeRequestDto) {
+	@ApiDocs.generateFindPwAuthCode('임시 비밀번호 발급을 위한 인증 메일 전송')
+	async generateFindPwAuthCode(@Body() authCodeReq: AuthCodeRequestDto) {
 		return await this.authCodesService.generateAuthCode(authCodeReq.email, AuthCodeType.FindPw);
 	}
 
 	@Post('/find-pw/verify')
+	@ApiDocs.verifyFindPwAuthCode('임시 비밀번호 발급을 위한 인증 코드 확인')
 	async verifyFindPwAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
 		return await this.authCodesService.verifyAuthCode(authCode, AuthCodeType.FindPw);
 	}

--- a/src/modules/auth-codes/auth-codes.controller.ts
+++ b/src/modules/auth-codes/auth-codes.controller.ts
@@ -18,13 +18,18 @@ export class AuthCodesController {
 	}
 
 	@Post('/signup/verify')
-	@ApiDocs.verifyAuthCode('회원가입 인증 코드 확인')
-	async verifyAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
-		return await this.authCodesService.verifyAuthCode(authCode);
+	@ApiDocs.verifySignUpAuthCode('회원가입 인증 코드 확인')
+	async verifySignUpAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
+		return await this.authCodesService.verifyAuthCode(authCode, AuthCodeType.SignUp);
 	}
 
 	@Post('/find-pw')
 	async findUsersPw(@Body() authCodeReq: AuthCodeRequestDto) {
 		return await this.authCodesService.generateAuthCode(authCodeReq.email, AuthCodeType.FindPw);
+	}
+
+	@Post('/find-pw/verify')
+	async verifyFindPwAuthCode(@Body() authCode: VerifyAuthCodeRequestDto) {
+		return await this.authCodesService.verifyAuthCode(authCode, AuthCodeType.FindPw);
 	}
 }

--- a/src/modules/auth-codes/auth-codes.controller.ts
+++ b/src/modules/auth-codes/auth-codes.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { AuthCodeType } from 'src/types/auth-code.types';
 import { ApiDocs } from './auth-codes.docs';
 import { AuthCodesService } from './auth-codes.service';
 import { AuthCodeRequestDto } from './dto/auth-code-request.dto';
@@ -13,7 +14,7 @@ export class AuthCodesController {
 	@Post('/signup')
 	@ApiDocs.generateSignUpAuthCode('회원가입을 위한 인증 메일 전송')
 	async generateSignUpAuthCode(@Body() authCodeReq: AuthCodeRequestDto) {
-		return await this.authCodesService.generateSignUpAuthCode(authCodeReq.email);
+		return await this.authCodesService.generateAuthCode(authCodeReq.email, AuthCodeType.SignUp);
 	}
 
 	@Post('/signup/verify')
@@ -24,6 +25,6 @@ export class AuthCodesController {
 
 	@Post('/find-pw')
 	async findUsersPw(@Body() authCodeReq: AuthCodeRequestDto) {
-		return await this.authCodesService.generateFindPwAuthCode(authCodeReq.email);
+		return await this.authCodesService.generateAuthCode(authCodeReq.email, AuthCodeType.FindPw);
 	}
 }

--- a/src/modules/auth-codes/auth-codes.docs.ts
+++ b/src/modules/auth-codes/auth-codes.docs.ts
@@ -1,12 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { boolean } from 'joi';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { AuthCodesController } from './auth-codes.controller';
 import { AuthCodeRequestDto } from './dto/auth-code-request.dto';
 import { AuthCodeResponseDto } from './dto/auth-code-response.dto';
 import { VerifyAuthCodeRequestDto } from './dto/verify-auth-code-request.dto';
+import { VerifyAuthCodeResponseDto } from './dto/verify-auth-code-response.dto';
 
 export const ApiDocs: SwaggerMethodDoc<AuthCodesController> = {
 	generateSignUpAuthCode(summary: string) {
@@ -29,7 +29,7 @@ export const ApiDocs: SwaggerMethodDoc<AuthCodesController> = {
 		return applyDecorators(
 			ApiOperation({
 				summary,
-				description: '회원가입 인증 코드 확인',
+				description: '회원가입을 위한 인증 코드 확인',
 			}),
 			ApiBody({
 				type: VerifyAuthCodeRequestDto,
@@ -37,7 +37,39 @@ export const ApiDocs: SwaggerMethodDoc<AuthCodesController> = {
 			ApiResponse({
 				status: 201,
 				description: '',
-				type: boolean,
+				type: VerifyAuthCodeResponseDto,
+			}),
+		);
+	},
+	generateFindPwAuthCode(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '임시 비밀번호 발급을 위한 인증코드 메일 발송 또는 재발송',
+			}),
+			ApiBody({
+				type: AuthCodeRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: AuthCodeResponseDto,
+			}),
+		);
+	},
+	verifyFindPwAuthCode(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '임시 비밀번호 발급을 위한 인증 코드 확인',
+			}),
+			ApiBody({
+				type: VerifyAuthCodeRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: VerifyAuthCodeResponseDto,
 			}),
 		);
 	},

--- a/src/modules/auth-codes/auth-codes.docs.ts
+++ b/src/modules/auth-codes/auth-codes.docs.ts
@@ -25,7 +25,7 @@ export const ApiDocs: SwaggerMethodDoc<AuthCodesController> = {
 			}),
 		);
 	},
-	verifyAuthCode(summary: string) {
+	verifySignUpAuthCode(summary: string) {
 		return applyDecorators(
 			ApiOperation({
 				summary,

--- a/src/modules/auth-codes/auth-codes.service.ts
+++ b/src/modules/auth-codes/auth-codes.service.ts
@@ -13,6 +13,7 @@ import { AuthCode } from 'src/entities/auth-code.entity';
 import { User } from 'src/entities/users.entity';
 import { AuthCodeType } from 'src/types/auth-code.types';
 import { MailAuthType } from 'src/types/mail-auth.types';
+import { AuthCodeResponseDto } from './dto/auth-code-response.dto';
 import { VerifyAuthCodeRequestDto } from './dto/verify-auth-code-request.dto';
 
 @Injectable()
@@ -25,7 +26,7 @@ export class AuthCodesService {
 		private readonly mailerService: MailerService,
 	) {}
 
-	async generateSignUpAuthCode(email: string) {
+	async generateSignUpAuthCode(email: string): Promise<AuthCodeResponseDto> {
 		const expiredAt: number = MailAuthType.ExpiredAt;
 		const code: string = Math.random().toString(36).slice(2, 10).toString();
 		const foundEmailUser = await this.usersRepository
@@ -37,8 +38,9 @@ export class AuthCodesService {
 		}
 		try {
 			const foundAuthCode = await this.authCodesRepository
-				.createQueryBuilder('userCode')
-				.where('userCode.email = :email', { email })
+				.createQueryBuilder('auth_code')
+				.where('auth_code.email = :email', { email })
+				.andWhere('auth_code.type = :type', { type: AuthCodeType.SignUp })
 				.getOne();
 
 			if (foundAuthCode) {
@@ -58,6 +60,51 @@ export class AuthCodesService {
 				// TODO: Template
 				html: `
 			<p>지금,여기에 오신 것을 환영해요! 아래 인증 코드를 지금,여기 앱에서 입력해주세요.</p>
+			<p>인증 코드: <span>${code}</span></p>
+			<p>인증코드는 이메일 발송 시점으로부터 ${expiredAt.toString()}분 동안 유효합니다.</p>
+			`,
+			});
+
+			return { expiredAt };
+		} catch (error) {
+			throw new InternalServerErrorException(error.message, error);
+		}
+	}
+
+	async generateFindPwAuthCode(email: string): Promise<AuthCodeResponseDto> {
+		const expiredAt: number = MailAuthType.ExpiredAt;
+		const code: string = Math.random().toString(36).slice(2, 10).toString();
+		const foundEmailUser = await this.usersRepository
+			.createQueryBuilder('user')
+			.where('user.email = :email', { email })
+			.getOne();
+		if (!foundEmailUser) {
+			throw new NotFoundException('User is not found');
+		}
+		try {
+			const foundAuthCode = await this.authCodesRepository
+				.createQueryBuilder('auth_code')
+				.where('auth_code.email = :email', { email })
+				.andWhere('auth_code.type = :type', { type: AuthCodeType.FindPw })
+				.getOne();
+
+			if (foundAuthCode) {
+				foundAuthCode.code = code;
+				await this.authCodesRepository.save(foundAuthCode);
+			} else {
+				await this.authCodesRepository.save({
+					email: email,
+					type: AuthCodeType.SignUp,
+					code: code,
+				});
+			}
+
+			this.mailerService.sendMail({
+				to: email,
+				subject: '[지금,여기] 이메일 인증 메일입니다 :)',
+				// TODO: Template
+				html: `
+			<p>임시 비밀번호 발급을 위한 메일입니다! 아래 인증 코드를 지금,여기 앱에서 입력해주세요.</p>
 			<p>인증 코드: <span>${code}</span></p>
 			<p>인증코드는 이메일 발송 시점으로부터 ${expiredAt.toString()}분 동안 유효합니다.</p>
 			`,

--- a/src/modules/auth-codes/dto/auth-code-response.dto.ts
+++ b/src/modules/auth-codes/dto/auth-code-response.dto.ts
@@ -5,4 +5,8 @@ export class AuthCodeResponseDto {
 	@IsNumber()
 	@ApiProperty({ example: 30, description: '인증코드 만료기간' })
 	readonly expiredAt: number;
+
+	constructor({ expiredAt }) {
+		this.expiredAt = expiredAt;
+	}
 }

--- a/src/modules/auth-codes/dto/verify-auth-code-response.dto.ts
+++ b/src/modules/auth-codes/dto/verify-auth-code-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class VerifyAuthCodeResponseDto {
+	@IsEmail()
+	@ApiProperty({ example: 'test@naver.com', description: '이메일' })
+	readonly email: string;
+
+	constructor({ email }) {
+		this.email = email;
+	}
+}

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -5,6 +5,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { User } from 'src/entities/users.entity';
+import { MailerModule } from 'src/mailer/mailer.module';
 import { MockUsersRepository } from '../../../test/mock/users.mock';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -18,7 +19,7 @@ describe('AuthController', () => {
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			imports: [HttpModule],
+			imports: [HttpModule, MailerModule],
 			controllers: [AuthController],
 			providers: [
 				AuthService,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { ApiBody, ApiTags } from '@nestjs/swagger';
 
 import { AuthUser, FacebookUser } from 'src/decorators/auth.decorator';
 import { UserType } from 'src/types/users.types';
+import { AuthCodeRequestDto } from '../auth-codes/dto/auth-code-request.dto';
 import { UserResponseDto } from '../users/dto/user-response.dto';
 import { ApiDocs } from './auth.docs';
 import { AuthService } from './auth.service';
@@ -84,5 +85,10 @@ export class AuthController {
 	@ApiDocs.refreshToken('access token 재발급')
 	async refreshToken(@AuthUser() user) {
 		return await this.authService.refresh(user);
+	}
+
+	@Post('find-pw')
+	async generateTempPw(@Body() authCodeReq: AuthCodeRequestDto) {
+		return await this.authService.generateTempPw(authCodeReq.email);
 	}
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -88,6 +88,7 @@ export class AuthController {
 	}
 
 	@Post('find-pw')
+	@ApiDocs.generateTempPw('임시 비밀번호 메일로 발송')
 	async generateTempPw(@Body() authCodeReq: AuthCodeRequestDto) {
 		return await this.authService.generateTempPw(authCodeReq.email);
 	}

--- a/src/modules/auth/auth.docs.ts
+++ b/src/modules/auth/auth.docs.ts
@@ -2,6 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
+import { AuthCodeRequestDto } from '../auth-codes/dto/auth-code-request.dto';
 import { UserResponseDto } from '../users/dto/user-response.dto';
 import { AuthController } from './auth.controller';
 import { KakaoLoginRequestDto } from './dto/kakao-login-request.dto';
@@ -125,6 +126,22 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 				type: TokenRefreshResponseDto,
 			}),
 			ApiBearerAuth('Authorization'),
+		);
+	},
+	generateTempPw(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '임시 비밀번호 메일로 발송',
+			}),
+			ApiBody({
+				type: AuthCodeRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
 		);
 	},
 };

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,3 +1,4 @@
+import { MailerService } from '@nestjs-modules/mailer';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
@@ -18,6 +19,13 @@ describe('AuthService', () => {
 			providers: [
 				AuthService,
 				HashPassword,
+				{
+					provide: MailerService,
+					useValue: {
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						post: jest.fn(() => {}),
+					},
+				},
 				{
 					provide: HttpService,
 					useValue: {

--- a/src/modules/users/dto/change-pw-request.dto.ts
+++ b/src/modules/users/dto/change-pw-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+export class ChangePwRequestDto {
+	@IsString()
+	@Length(8, 24)
+	@ApiProperty({ example: '1234abcd!', description: '기존 패스워드' })
+	readonly originPw: string;
+
+	@IsString()
+	@Length(8, 24)
+	@ApiProperty({ example: '1234abcd!!', description: '새로운 패스워드' })
+	readonly newPw: string;
+}

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -7,6 +7,7 @@ import { User } from 'src/entities/users.entity';
 import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockTasteSpotsRepository } from 'test/mock/taste-spots.mock';
 import { MockUsersRepository } from 'test/mock/users.mock';
+import { HashPassword } from '../auth/hash-password';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
@@ -18,6 +19,7 @@ describe('UsersController', () => {
 			controllers: [UsersController],
 			providers: [
 				UsersService,
+				HashPassword,
 				{
 					provide: getRepositoryToken(User),
 					useClass: MockUsersRepository,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { AuthUser } from 'src/decorators/auth.decorator';
@@ -6,6 +6,7 @@ import { Roles } from 'src/decorators/roles.decorator';
 import { UserType } from 'src/types/users.types';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/role.guard';
+import { ChangePwRequestDto } from './dto/change-pw-request.dto';
 import { UserTasteSpotsRequestDto } from './dto/user-taste-spots-request.dto';
 import { ApiDocs } from './users.docs';
 import { UsersService } from './users.service';
@@ -34,5 +35,11 @@ export class UsersController {
 	@ApiDocs.createUsersTasteSpots('사용자의 여행지 취향 저장')
 	async createUsersTasteSpots(@AuthUser() userData, @Body() tasteSpotsDto: UserTasteSpotsRequestDto) {
 		return await this.usersService.createUsersTasteSpots(userData.id, tasteSpotsDto.tasteSpots);
+	}
+
+	@Patch('/change-pw')
+	@ApiDocs.updateUsersPw('사용자 비밀번호 변경')
+	async updateUsersPw(@AuthUser() userData, @Body() changePwDto: ChangePwRequestDto) {
+		return await this.usersService.updateUsersPw(userData, changePwDto);
 	}
 }

--- a/src/modules/users/users.docs.ts
+++ b/src/modules/users/users.docs.ts
@@ -2,6 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
+import { ChangePwRequestDto } from './dto/change-pw-request.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UserTasteSpotsRequestDto } from './dto/user-taste-spots-request.dto';
 import { UsersController } from './users.controller';
@@ -45,6 +46,23 @@ export const ApiDocs: SwaggerMethodDoc<UsersController> = {
 			}),
 			ApiResponse({
 				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	updateUsersPw(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '사용자 비밀번호 변경',
+			}),
+			ApiBody({
+				type: ChangePwRequestDto,
+			}),
+			ApiResponse({
+				status: 200,
 				description: '',
 				type: Boolean,
 			}),

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,12 +4,13 @@ import { Spot } from 'src/entities/spots.entity';
 import { TasteSpot } from 'src/entities/taste-spots.entity';
 
 import { User } from 'src/entities/users.entity';
+import { HashPassword } from '../auth/hash-password';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
 	imports: [TypeOrmModule.forFeature([User, TasteSpot, Spot])],
 	controllers: [UsersController],
-	providers: [UsersService],
+	providers: [UsersService, HashPassword],
 })
 export class UsersModule {}

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -7,6 +7,7 @@ import { User } from 'src/entities/users.entity';
 import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockTasteSpotsRepository } from 'test/mock/taste-spots.mock';
 import { MockUsersRepository } from 'test/mock/users.mock';
+import { HashPassword } from '../auth/hash-password';
 import { UsersService } from './users.service';
 
 describe('UsersService', () => {
@@ -17,6 +18,7 @@ describe('UsersService', () => {
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				UsersService,
+				HashPassword,
 				{
 					provide: getRepositoryToken(User),
 					useClass: MockUsersRepository,

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,10 +1,19 @@
-import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+	BadRequestException,
+	Injectable,
+	InternalServerErrorException,
+	NotFoundException,
+	UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { Spot } from 'src/entities/spots.entity';
 import { TasteSpot } from 'src/entities/taste-spots.entity';
 import { User } from 'src/entities/users.entity';
+import { UserType } from 'src/types/users.types';
+import { HashPassword } from '../auth/hash-password';
+import { ChangePwRequestDto } from './dto/change-pw-request.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 
 @Injectable()
@@ -16,6 +25,7 @@ export class UsersService {
 		private readonly tasteSpotsRepository: Repository<TasteSpot>,
 		@InjectRepository(Spot)
 		private readonly spotsRepository: Repository<Spot>,
+		private hashPassword: HashPassword,
 	) {}
 
 	async getUser(userId: number): Promise<UserResponseDto> {
@@ -63,6 +73,23 @@ export class UsersService {
 		}
 	}
 
+	async updateUsersPw(user, changePwDto: ChangePwRequestDto): Promise<boolean> {
+		await this.errIfUpdatePwReqIsBad(user, changePwDto);
+
+		const foundUser = await this.usersRepository
+			.createQueryBuilder('user')
+			.where('user.id = :id', { id: user.id })
+			.getOne();
+
+		if (!(await this.isValidPassword(foundUser.password, changePwDto.originPw))) {
+			throw new UnauthorizedException('Password is incorrect');
+		}
+		foundUser.password = await this.hashPassword.hash(changePwDto.newPw);
+		await this.usersRepository.update(user.id, foundUser);
+
+		return true;
+	}
+
 	private isDuplicateArr(arr: any): boolean {
 		const set = new Set(arr);
 
@@ -77,5 +104,19 @@ export class UsersService {
 
 		if (foundSpots.length !== spots.length) return true;
 		return false;
+	}
+
+	private async errIfUpdatePwReqIsBad(user, changePwDto: ChangePwRequestDto) {
+		if (user.role === UserType.Kakao) {
+			throw new BadRequestException('User is kakao user');
+		} else if (user.role === UserType.Facebook) {
+			throw new BadRequestException('User is facebook user');
+		} else if (changePwDto.originPw === changePwDto.newPw) {
+			throw new BadRequestException('originPw and newPw are the same');
+		}
+	}
+
+	private async isValidPassword(original: string, target: string) {
+		return await this.hashPassword.equal({ password: target, hashPassword: original });
 	}
 }

--- a/src/types/ad-form.types.ts
+++ b/src/types/ad-form.types.ts
@@ -1,4 +1,5 @@
 export enum AdFormType {
 	Todo = 'Todo',
-	Complete = 'Complete',
+	Approve = 'Approve',
+	Reject = 'Reject',
 }


### PR DESCRIPTION
## 개요
- 사용자 비밀번호 찾기 api를 구현했습니다.
- 사용자 비밀번호 변경 api를 구현했습니다.
## api
- auth-codes/find-pw : 비밀번호 찾기 시 인증 메일 발송
- auth-codes/find-pw/verify : 비밀번호 찾기 시 인증 코드 검증
- auth/find-pw : 임시 비밀번호 메일로 발급
- users/change-pw : 비밀번호 수정
## 테스트
- 인증메일이 발송되는지
- 인증코드로 검증이 되는지
- 임시 비밀번호를 발급받고, 그 비밀번호로 로그인이 가능한지
- 비밀번호 수정 후 로그인이 되는지 (소셜 유저인경우 에러, 비밀번호가 틀릴 경우 에러)