### PR TITLE
Feat: Return additional location at spot response

### DIFF
--- a/src/modules/spots/dto/detail-spot-response.dto.ts
+++ b/src/modules/spots/dto/detail-spot-response.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsNumber, IsString } from 'class-validator';
 
+import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
+
 export class DetailSpotResponseDto<T> {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -22,16 +24,20 @@ export class DetailSpotResponseDto<T> {
 	@ApiProperty({ example: 1, description: '호감도' })
 	readonly snsPostLikeNumber: number;
 
+	@ApiProperty({ description: '위치 정보' })
+	readonly location: LocationResponseDto;
+
 	@IsArray()
 	@ApiProperty({ isArray: true, example: '관련 sns 게시글 정보' })
 	readonly detailSnsPost: T[];
 
-	constructor({ id, name, latitude, longitude, snsPostLikeNumber, detailSnsPost }) {
+	constructor({ id, name, latitude, longitude, snsPostLikeNumber, location, detailSnsPost }) {
 		this.id = id;
 		this.name = name;
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.snsPostLikeNumber = snsPostLikeNumber;
+		this.location = new LocationResponseDto(location);
 		this.detailSnsPost = detailSnsPost;
 	}
 }

--- a/src/modules/spots/dto/search-response.dto.ts
+++ b/src/modules/spots/dto/search-response.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
+import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
+
 export class SearchResponseDto {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -10,8 +12,12 @@ export class SearchResponseDto {
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
 
-	constructor({ id, name }) {
+	@ApiProperty({ description: '위치 정보' })
+	readonly location: LocationResponseDto;
+
+	constructor({ id, name, location }) {
 		this.id = id;
 		this.name = name;
+		this.location = new LocationResponseDto(location);
 	}
 }

--- a/test/mock/locations.mock.ts
+++ b/test/mock/locations.mock.ts
@@ -7,6 +7,7 @@ export const mockLocation = {
 export class MockLocationsRepository {
 	save = jest.fn().mockResolvedValue(mockLocation);
 	find = jest.fn().mockReturnThis();
+	findOne = jest.fn().mockReturnThis();
 
 	async findLocation() {
 		return mockLocation;


### PR DESCRIPTION
## 작업사항
- 여행지 상세정보, 검색 페이지 반환 목록에 location 추가했습니다.
- detail-spot-response.dto.ts, search-response.dto.ts

## 테스트
- 여행지 상세 페이지, 검색 목록에서 여행지마다 location 잘 나타나는지 확인