### PR TITLE
Feat: duplicate filtering spots and nearby facilities

### DIFF
--- a/src/modules/spots/dto/detail-spot-request.dto.ts
+++ b/src/modules/spots/dto/detail-spot-request.dto.ts
@@ -2,4 +2,4 @@ import { PickType } from '@nestjs/swagger';
 
 import { SearchRequestDto } from './search-request.dto';
 
-export class DetailSpotRequestDto extends PickType(SearchRequestDto, ['themeId', 'take'] as const) {}
+export class DetailSpotRequestDto extends PickType(SearchRequestDto, ['take'] as const) {}

--- a/src/modules/spots/dto/detail-spot-response.dto.ts
+++ b/src/modules/spots/dto/detail-spot-response.dto.ts
@@ -3,7 +3,7 @@ import { IsArray, IsNumber, IsString } from 'class-validator';
 
 import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 
-export class DetailSpotResponseDto<T> {
+export class DetailSpotResponseDto<S, N> {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
 	readonly id: number;
@@ -29,9 +29,13 @@ export class DetailSpotResponseDto<T> {
 
 	@IsArray()
 	@ApiProperty({ isArray: true, example: '관련 sns 게시글 정보' })
-	readonly detailSnsPost: T[];
+	readonly detailSnsPost: S[];
 
-	constructor({ id, name, latitude, longitude, snsPostLikeNumber, location, detailSnsPost }) {
+	@IsArray()
+	@ApiProperty({ isArray: true, example: '여행지 주변 시설' })
+	readonly neaybyFacility: N[];
+
+	constructor({ id, name, latitude, longitude, snsPostLikeNumber, location, detailSnsPost, neaybyFacility }) {
 		this.id = id;
 		this.name = name;
 		this.latitude = latitude;
@@ -39,5 +43,6 @@ export class DetailSpotResponseDto<T> {
 		this.snsPostLikeNumber = snsPostLikeNumber;
 		this.location = new LocationResponseDto(location);
 		this.detailSnsPost = detailSnsPost;
+		this.neaybyFacility = neaybyFacility;
 	}
 }

--- a/src/modules/spots/dto/neayby-facility-response.dto.ts
+++ b/src/modules/spots/dto/neayby-facility-response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
+
+export class NeayByFacilityResponseDto {
+	@IsString()
+	@ApiProperty({ example: '식당', description: '여행지 주변 시설 이름' })
+	readonly name: string;
+
+	@IsString()
+	@ApiProperty({ example: 'http://place.map.kakao.com/23994694', description: '주변 시설 주소' })
+	readonly placeUrl: string;
+
+	@IsString()
+	@ApiProperty({ example: '인천 옹진군 자월면 승봉로29번길 15', description: '주소 이름' })
+	readonly address: string;
+
+	@IsString()
+	@ApiProperty({ example: 3416, description: '여행지로부터 떨어진 거리' })
+	readonly distance: number;
+
+	@IsNumber()
+	@ApiProperty({ example: '음식점', description: '주변 시설 카테고리' })
+	readonly category: string;
+
+	constructor({ name, placeUrl, address, distance, category }) {
+		this.name = name;
+		this.placeUrl = placeUrl;
+		this.address = address;
+		this.distance = distance;
+		this.category = category;
+	}
+}

--- a/src/modules/spots/dto/search-request.dto.ts
+++ b/src/modules/spots/dto/search-request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 import { SortType } from 'src/types/sort.types';
 
@@ -31,15 +31,13 @@ export class SearchRequestDto {
 	@ApiProperty({ default: 20, description: '페이지 별 데이터 개수' })
 	readonly take?: number = 20;
 
-	@IsNumber()
 	@IsOptional()
-	@Type(() => Number)
-	@ApiProperty({ example: 1, description: '위치 id' })
-	locationId?: number;
+	@Transform((params) => params.value.split(',').map(Number))
+	@ApiProperty({ example: [1, 10], description: '위치 필터링 id list' })
+	readonly locationIds?: number[];
 
-	@IsNumber()
 	@IsOptional()
-	@Type(() => Number)
-	@ApiProperty({ example: 1, description: '테마 id' })
-	themeId?: number;
+	@Transform((params) => params.value.split(',').map(Number))
+	@ApiProperty({ example: [1, 2, 3], description: '테마 필터링 id list' })
+	readonly themeIds?: string[];
 }

--- a/src/modules/spots/dto/search-request.dto.ts
+++ b/src/modules/spots/dto/search-request.dto.ts
@@ -33,11 +33,11 @@ export class SearchRequestDto {
 
 	@IsOptional()
 	@Transform((params) => params.value.split(',').map(Number))
-	@ApiProperty({ example: [1, 10], description: '위치 필터링 id list' })
+	@ApiProperty({ example: '1,10', description: '위치 필터링 id list' })
 	readonly locationIds?: number[];
 
 	@IsOptional()
 	@Transform((params) => params.value.split(',').map(Number))
-	@ApiProperty({ example: [1, 2, 3], description: '테마 필터링 id list' })
+	@ApiProperty({ example: '1,2,3', description: '테마 필터링 id list' })
 	readonly themeIds?: string[];
 }

--- a/src/modules/spots/dto/search-request.dto.ts
+++ b/src/modules/spots/dto/search-request.dto.ts
@@ -39,5 +39,5 @@ export class SearchRequestDto {
 	@IsOptional()
 	@Transform((params) => params.value.split(',').map(Number))
 	@ApiProperty({ example: '1,2,3', description: '테마 필터링 id list' })
-	readonly themeIds?: string[];
+	readonly themeIds?: number[];
 }

--- a/src/modules/spots/spots.controller.spec.ts
+++ b/src/modules/spots/spots.controller.spec.ts
@@ -1,7 +1,8 @@
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { ConfigService } from '@nestjs/config';
 import { Location } from 'src/entities/locations.entity';
 import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
@@ -14,12 +15,15 @@ import { MockThemeRepository } from 'test/mock/theme.mock';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsController } from './spots.controller';
 import { SpotsService } from './spots.service';
+import { KakaoAuthStrategy } from '../auth/strategies/kakao-auth.strategy';
 
 describe('SpotsController', () => {
 	let spotsController: SpotsController;
+	let spotsService: SpotsService;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
+			imports: [HttpModule],
 			controllers: [SpotsController],
 			providers: [
 				SpotsService,
@@ -27,31 +31,28 @@ describe('SpotsController', () => {
 					provide: getRepositoryToken(Location),
 					useClass: MockLocationsRepository,
 				},
-				SpotsService,
 				{
 					provide: getRepositoryToken(Spot),
 					useClass: MockSpotsRepository,
 				},
-				SpotsService,
 				{
 					provide: getRepositoryToken(Theme),
 					useClass: MockThemeRepository,
 				},
-				SpotsService,
 				{
 					provide: getRepositoryToken(SnsPost),
 					useClass: MockSnsPostsRepository,
 				},
-				SpotsService,
 				{
 					provide: getRepositoryToken(Rank),
 					useClass: MockSnsPostsRepository,
 				},
+				KakaoAuthStrategy,
 				{
 					provide: ConfigService,
 					useValue: {
 						get: jest.fn((key: string) => {
-							if (key === 'sshConfig') {
+							if (key === 'oauthConfig') {
 								return 1;
 							}
 							return null;
@@ -63,6 +64,7 @@ describe('SpotsController', () => {
 		}).compile();
 
 		spotsController = module.get<SpotsController>(SpotsController);
+		spotsService = module.get<SpotsService>(SpotsService);
 	});
 	it('should be defined', () => {
 		expect(spotsController).toBeDefined();

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { boolean } from 'joi';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
@@ -60,14 +60,14 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '페이지 별 데이터 개수',
 			}),
 			ApiQuery({
-				name: 'locationId',
+				name: 'locationIds',
 				required: false,
-				description: '위치 id',
+				description: '위치 필터링 id list',
 			}),
 			ApiQuery({
-				name: 'themeId',
+				name: 'themeIds',
 				required: false,
-				description: '테마 id',
+				description: '테마 필터링 id list',
 			}),
 			ApiResponse({
 				status: 200,
@@ -83,19 +83,9 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '여행지 상세 페이지(여행지 기본 정보, 연관 sns posts',
 			}),
 			ApiQuery({
-				name: 'themeId',
-				required: false,
-				description: '테마 id',
-			}),
-			ApiQuery({
 				name: 'take',
 				required: false,
 				description: '페이지 별 데이터 개수',
-			}),
-			ApiParam({
-				name: 'spotId',
-				required: true,
-				description: '여행지 id',
 			}),
 			ApiResponse({
 				status: 200,

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -3,10 +3,8 @@ import { ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiQuery, ApiResponse } f
 import { boolean } from 'joi';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
-import { DetailSpotRequestDto } from './dto/detail-spot-request.dto';
 import { DetailSpotResponseDto } from './dto/detail-spot-response.dto';
-import { SearchRequestDto } from './dto/search-request.dto';
-import { SearchResponseDto } from './dto/search-response.dto';
+import { SearchPageResponseDto } from './dto/search-page-response.dto';
 import { SpotsController } from './spots.controller';
 
 export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
@@ -42,12 +40,39 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '여행지 검색(단어 검색, 정렬, 필터링, 페이지네이션)',
 			}),
 			ApiQuery({
-				type: SearchRequestDto,
+				name: 'word',
+				required: false,
+				description: '검색어',
+			}),
+			ApiQuery({
+				name: 'sorter',
+				required: false,
+				description: '정렬 기준 (이름순: Name, 인기순: Rank)',
+			}),
+			ApiQuery({
+				name: 'page',
+				required: false,
+				description: '페이지 번호',
+			}),
+			ApiQuery({
+				name: 'take',
+				required: false,
+				description: '페이지 별 데이터 개수',
+			}),
+			ApiQuery({
+				name: 'locationId',
+				required: false,
+				description: '위치 id',
+			}),
+			ApiQuery({
+				name: 'themeId',
+				required: false,
+				description: '테마 id',
 			}),
 			ApiResponse({
 				status: 200,
 				description: '',
-				type: [SearchResponseDto],
+				type: SearchPageResponseDto,
 			}),
 		);
 	},
@@ -58,11 +83,19 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '여행지 상세 페이지(여행지 기본 정보, 연관 sns posts',
 			}),
 			ApiQuery({
-				type: DetailSpotRequestDto,
+				name: 'themeId',
+				required: false,
+				description: '테마 id',
+			}),
+			ApiQuery({
+				name: 'take',
+				required: false,
+				description: '페이지 별 데이터 개수',
 			}),
 			ApiParam({
-				name: 'spodId',
-				type: Number,
+				name: 'spotId',
+				required: true,
+				description: '여행지 id',
 			}),
 			ApiResponse({
 				status: 200,

--- a/src/modules/spots/spots.module.ts
+++ b/src/modules/spots/spots.module.ts
@@ -10,9 +10,10 @@ import { SpotsController } from './spots.controller';
 import { SpotsService } from './spots.service';
 import { RanksService } from '../ranks/ranks.service';
 import { RanksModule } from '../ranks/ranks.module';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-	imports: [RanksModule, TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank])],
+	imports: [HttpModule, RanksModule, TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank])],
 	controllers: [SpotsController],
 	providers: [SpotsService, RanksService],
 })

--- a/src/modules/spots/spots.service.spec.ts
+++ b/src/modules/spots/spots.service.spec.ts
@@ -16,6 +16,7 @@ import { DetailSpotRequestDto } from './dto/detail-spot-request.dto';
 import { ConfigService } from '@nestjs/config';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsService } from './spots.service';
+import { HttpService } from '@nestjs/axios';
 
 describe('SpotsService', () => {
 	let spotsService: SpotsService;
@@ -54,11 +55,19 @@ describe('SpotsService', () => {
 					provide: ConfigService,
 					useValue: {
 						get: jest.fn((key: string) => {
-							if (key === 'sshConfig') {
+							if (key === 'oauthConfig') {
 								return 1;
 							}
 							return null;
 						}),
+					},
+				},
+				{
+					provide: HttpService,
+					useValue: {
+						//TODO:
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						post: jest.fn(() => {}),
 					},
 				},
 				RanksService,

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -387,11 +387,9 @@ export class SpotsService {
 
 	private async getNearbyFacility(latitude, longitude) {
 		try {
-			const keyword = '맛집';
 			const kakaoRequestApiMapResult = await firstValueFrom(
 				this.httpService.get(
-					`https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURI(keyword)}
-				&y=${latitude}&x=${longitude}&radius=10000&sort=distance`,
+					`https://dapi.kakao.com/v2/local/search/category.json?category\_group\_code=PK6,FD6,CE7&y=${latitude}&x=${longitude}&radius=20000&sort=distance`,
 					{
 						headers: {
 							Authorization: `KakaoAK ${this.#oauthConfig.clientId}`,


### PR DESCRIPTION
## 개요
여행지 필터링 중복 선택 및 전체 선택 가능하게 변경하였습니다.
여행지 상세 페이지에서 주변 시설이 나오도록 추가하였습니다.

## 작업사항
- 위치 필터링, 테마 필터링 중복 선택 가능
- 위치 필터링 전체 선택 시 해당 위치 전체 반환
- 여행지 상세 페이지 sns post 좋아요 순 정렬
- 여행지 상세 페이지 접속 시 카카오 맵 api를 사용하여 주변 시설들 반환(음식점, 카페, 주차장)
- spot swagger 정리

## 테스트
- 필터링 중복 및 전체 선택 시 잘 나오는지 확인
- 여행지 상세 페이지 주변 시설 확인

## 논의 사항
- 주변 시설 내용을 이름, 주소, url, 거리, 카테고리로 반환했는데 적절한지
- 주변 시설을 한 페이지에 1~15 개 정도 반환 가능해서 15개로 설정했는데 너무 많은지(or 페이지가 필요할지 등)
- 카테고리를 맛집으로 설정해서 '음식점', '카페' 가 나오는데 다른 카테고리가 필요할지
논의 사항과 관련된 내용(반환 내용, 카테고리)은 아래 링크에서 확인 가능
(https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-category)