### PR TITLE
Feat: Community's comment api

### DIFF
--- a/src/entities/post-comments.entity.ts
+++ b/src/entities/post-comments.entity.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 
 import { CommonEntity } from './common.entity';
@@ -38,9 +38,4 @@ export class PostComment extends CommonEntity {
 	@IsNotEmpty()
 	@Column({ type: 'varchar', length: 400, nullable: false })
 	content: string;
-
-	@IsBoolean()
-	@IsNotEmpty()
-	@Column({ name: 'is_writer', type: 'boolean', nullable: false, default: false })
-	isWriter: boolean;
 }

--- a/src/entities/post-comments.entity.ts
+++ b/src/entities/post-comments.entity.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 
 import { CommonEntity } from './common.entity';
@@ -38,4 +38,9 @@ export class PostComment extends CommonEntity {
 	@IsNotEmpty()
 	@Column({ type: 'varchar', length: 400, nullable: false })
 	content: string;
+
+	@IsBoolean()
+	@IsNotEmpty()
+	@Column({ name: 'is_writer', type: 'boolean', nullable: false, default: false })
+	isWriter: boolean;
 }

--- a/src/entities/post-comments.entity.ts
+++ b/src/entities/post-comments.entity.ts
@@ -1,0 +1,41 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Post } from './posts.entity';
+import { User } from './users.entity';
+
+@Entity()
+export class PostComment extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.postComments, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'post_id' })
+	postId: number;
+
+	@ManyToOne(() => Post, (post: Post) => post.postComments, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([
+		{
+			name: 'post_id',
+			referencedColumnName: 'id',
+		},
+	])
+	post: Post;
+
+	@IsString()
+	@IsNotEmpty()
+	@Column({ type: 'varchar', length: 400, nullable: false })
+	content: string;
+}

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 
 import { CommonEntity } from './common.entity';
 import { Location } from './locations.entity';
+import { PostComment } from './post-comments.entity';
 import { PostTheme } from './post-themes.entity';
 import { User } from './users.entity';
 
@@ -55,4 +56,10 @@ export class Post extends CommonEntity {
 		eager: true,
 	})
 	postThemes: PostTheme[];
+
+	@OneToMany(() => PostComment, (postComment: PostComment) => postComment.post, {
+		cascade: true,
+		eager: true,
+	})
+	postComments: PostComment[];
 }

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity, OneToMany } from 'typeorm';
 
 import { UserType } from 'src/types/users.types';
 import { CommonEntity } from './common.entity';
+import { PostComment } from './post-comments.entity';
 import { Post } from './posts.entity';
 import { TasteTheme } from './taste-themes.entity';
 
@@ -50,4 +51,10 @@ export class User extends CommonEntity {
 		cascade: true,
 	})
 	posts: Post[];
+
+	@OneToMany(() => PostComment, (postComment: PostComment) => postComment.user, {
+		cascade: true,
+		eager: true,
+	})
+	postComments: PostComment[];
 }

--- a/src/modules/posts/dto/get-posts-comments-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-comments-response.dto.ts
@@ -22,10 +22,10 @@ export class GetPostsCommentsResponseDto {
 	@ApiProperty({ description: '작성자 정보' })
 	readonly user: CommentsUserResponseDto;
 
-	constructor({ id, content, is_writer, created_at, user }) {
+	constructor({ id, content, isWriter, created_at, user }) {
 		this.id = id;
 		this.content = content;
-		this.isWriter = is_writer;
+		this.isWriter = isWriter;
 		this.createdAt = created_at;
 		this.user = user;
 	}

--- a/src/modules/posts/dto/get-posts-comments-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-comments-response.dto.ts
@@ -12,7 +12,7 @@ export class GetPostsCommentsResponseDto {
 	readonly content: string;
 
 	@IsBoolean()
-	@ApiProperty({ example: true, description: '게시글 작성자 유무' })
+	@ApiProperty({ example: true, description: '댓글 작성자 유무' })
 	readonly isWriter: boolean;
 
 	@IsDateString()

--- a/src/modules/posts/dto/get-posts-comments-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-comments-response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsDateString, IsNumber, IsString } from 'class-validator';
+import { CommentsUserResponseDto } from 'src/modules/users/dto/comments-user-response.dto';
+
+export class GetPostsCommentsResponseDto {
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '댓글 id' })
+	readonly id: number;
+
+	@IsString()
+	@ApiProperty({ example: 'test', description: '댓글 내용' })
+	readonly content: string;
+
+	@IsBoolean()
+	@ApiProperty({ example: true, description: '게시글 작성자 유무' })
+	readonly isWriter: boolean;
+
+	@IsDateString()
+	@ApiProperty({ example: '2022-11-11', description: '댓글 작성 날짜' })
+	readonly createdAt: Date;
+
+	@ApiProperty({ description: '작성자 정보' })
+	readonly user: CommentsUserResponseDto;
+
+	constructor({ id, content, is_writer, created_at, user }) {
+		this.id = id;
+		this.content = content;
+		this.isWriter = is_writer;
+		this.createdAt = created_at;
+		this.user = user;
+	}
+}

--- a/src/modules/posts/dto/get-posts-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-response.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsDateString, IsNumber, IsString } from 'class-validator';
 import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 import { ThemeResponseDto } from 'src/modules/filters/dto/theme-response.dto';
+import { CommentsUserResponseDto } from 'src/modules/users/dto/comments-user-response.dto';
 
 export class GetPostsResponseDto {
 	@IsNumber()
@@ -29,6 +30,9 @@ export class GetPostsResponseDto {
 	@ApiProperty({ example: '2022-11-11', description: '작성 날짜' })
 	readonly createdAt: Date;
 
+	@ApiProperty({ description: '작성자 정보' })
+	readonly user: CommentsUserResponseDto;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
@@ -37,13 +41,14 @@ export class GetPostsResponseDto {
 	@ApiProperty({ description: '테마 정보' })
 	readonly themes: ThemeResponseDto[];
 
-	constructor({ id, title, content, photo_urls, isWriter, created_at, location, themes }) {
+	constructor({ id, title, content, photo_urls, isWriter, created_at, user, location, themes }) {
 		this.id = id;
 		this.title = title;
 		this.content = content;
 		this.photoUrls = photo_urls;
 		this.isWriter = isWriter;
 		this.createdAt = created_at;
+		this.user = user;
 		this.location = location;
 		this.themes = themes;
 	}

--- a/src/modules/posts/dto/get-posts-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-response.dto.ts
@@ -15,7 +15,7 @@ export class GetPostsResponseDto {
 
 	@IsString()
 	@ApiProperty({ example: 'test', description: '내용' })
-	readonly content: string;
+	readonly content?: string | null;
 
 	@IsArray()
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })

--- a/src/modules/posts/dto/get-posts-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsDateString, IsNumber, IsString } from 'class-validator';
 import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 import { ThemeResponseDto } from 'src/modules/filters/dto/theme-response.dto';
 
@@ -23,7 +23,11 @@ export class GetPostsResponseDto {
 
 	@IsBoolean()
 	@ApiProperty({ example: true, description: '작성자 유무' })
-	readonly writer: boolean;
+	readonly isWriter: boolean;
+
+	@IsDateString()
+	@ApiProperty({ example: '2022-11-11', description: '작성 날짜' })
+	readonly createdAt: Date;
 
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
@@ -33,12 +37,13 @@ export class GetPostsResponseDto {
 	@ApiProperty({ description: '테마 정보' })
 	readonly themes: ThemeResponseDto[];
 
-	constructor({ id, title, content, photo_urls, writer, location, themes }) {
+	constructor({ id, title, content, photo_urls, isWriter, created_at, location, themes }) {
 		this.id = id;
 		this.title = title;
 		this.content = content;
 		this.photoUrls = photo_urls;
-		this.writer = writer;
+		this.isWriter = isWriter;
+		this.createdAt = created_at;
 		this.location = location;
 		this.themes = themes;
 	}

--- a/src/modules/posts/dto/post-comments-request.dto.ts
+++ b/src/modules/posts/dto/post-comments-request.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class PostCommentsRequestDto {
+	@IsString()
+	@ApiProperty({ example: 'test', description: '내용' })
+	readonly content: string;
+}

--- a/src/modules/posts/dto/post-comments-response.dto.ts
+++ b/src/modules/posts/dto/post-comments-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class PostCommentsResponseDto {
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '커뮤니티 게시글 댓글 id' })
+	readonly id: number;
+
+	constructor({ id }) {
+		this.id = id;
+	}
+}

--- a/src/modules/posts/dto/posts-request.dto.ts
+++ b/src/modules/posts/dto/posts-request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayMinSize, IsArray, IsString } from 'class-validator';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsOptional, IsString } from 'class-validator';
 
 export class PostsRequestDto {
 	@IsString()
@@ -8,8 +8,9 @@ export class PostsRequestDto {
 	readonly title: string;
 
 	@IsString()
+	@IsOptional()
 	@ApiProperty({ example: 'test', description: '내용' })
-	readonly content: string;
+	readonly content?: string | null;
 
 	@IsString()
 	@ApiProperty({ example: '서울특별시 ~~', description: '주소' })

--- a/src/modules/posts/posts.controller.spec.ts
+++ b/src/modules/posts/posts.controller.spec.ts
@@ -2,10 +2,12 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Location } from 'src/entities/locations.entity';
+import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
+import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
 import { MockPostThemesRepository } from 'test/mock/postThemes.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
@@ -35,6 +37,10 @@ describe('PostsController', () => {
 				{
 					provide: getRepositoryToken(PostTheme),
 					useClass: MockPostThemesRepository,
+				},
+				{
+					provide: getRepositoryToken(PostComment),
+					useClass: MockPostCommentsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -110,4 +110,10 @@ export class PostsController {
 	) {
 		return await this.postsService.createPostsComments(userData.id, postId, commentData);
 	}
+
+	@Get(':postId/comments')
+	@ApiDocs.getPostsComments('커뮤니티 게시글 댓글 목록')
+	async getPostsComments(@AuthUser() userData, @Param('postId') postId: number) {
+		return await this.postsService.getPostsComments(userData.id, postId);
+	}
 }

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -116,4 +116,14 @@ export class PostsController {
 	async getPostsComments(@AuthUser() userData, @Param('postId') postId: number) {
 		return await this.postsService.getPostsComments(userData.id, postId);
 	}
+
+	@Delete(':postId/comments/:commentId')
+	@ApiDocs.deletePostsComment('커뮤니티 게시글 댓글 삭제')
+	async deletePostsComment(
+		@AuthUser() userData,
+		@Param('postId') postId: number,
+		@Param('commentId') commentId: number,
+	) {
+		return await this.postsService.deletePostsComment(userData.id, postId, commentId);
+	}
 }

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -16,6 +16,7 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthUser } from 'src/decorators/auth.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
 import { PostsRequestDto } from './dto/posts-request.dto';
 import { UpdatePostsRequestDto } from './dto/update-posts-request.dto';
 import { ApiDocs } from './posts.docs';
@@ -98,5 +99,15 @@ export class PostsController {
 	@ApiDocs.deletePost('커뮤니티 게시글 삭제')
 	async deletePost(@AuthUser() userData, @Param('postId') postId: number) {
 		return await this.postsService.deletePost(userData.id, postId);
+	}
+
+	@Post(':postId/comments')
+	@ApiDocs.createPostsComments('커뮤니티 게시글 댓글 작성')
+	async createPostsComments(
+		@AuthUser() userData,
+		@Param('postId') postId: number,
+		@Body() commentData: PostCommentsRequestDto,
+	) {
+		return await this.postsService.createPostsComments(userData.id, postId, commentData);
 	}
 }

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -3,6 +3,8 @@ import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiRespons
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { GetPostsResponseDto } from './dto/get-posts-response.dto';
+import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
+import { PostCommentsResponseDto } from './dto/post-comments-response.dto';
 import { PostsResponseDto } from './dto/posts-response.dto';
 import { PostsController } from './posts.controller';
 
@@ -131,6 +133,27 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 				status: 204,
 				description: '삭제 완료',
 				type: PostsResponseDto,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	createPostsComments(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '커뮤니티 게시글 댓글 작성',
+			}),
+			ApiParam({
+				name: 'postId',
+				type: Number,
+			}),
+			ApiBody({
+				type: PostCommentsRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: PostCommentsResponseDto,
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -2,6 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
+import { GetPostsCommentsResponseDto } from './dto/get-posts-comments-response.dto';
 import { GetPostsResponseDto } from './dto/get-posts-response.dto';
 import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
 import { PostCommentsResponseDto } from './dto/post-comments-response.dto';
@@ -154,6 +155,24 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 				status: 201,
 				description: '',
 				type: PostCommentsResponseDto,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	getPostsComments(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '커뮤니티 게시글 댓글 목록',
+			}),
+			ApiParam({
+				name: 'postId',
+				type: Number,
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: [GetPostsCommentsResponseDto],
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -133,7 +133,7 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 			ApiResponse({
 				status: 204,
 				description: '삭제 완료',
-				type: PostsResponseDto,
+				type: Boolean,
 			}),
 			ApiBearerAuth('Authorization'),
 		);
@@ -173,6 +173,28 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 				status: 200,
 				description: '',
 				type: [GetPostsCommentsResponseDto],
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	deletePostsComment(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '커뮤니티 게시글 댓글 삭제',
+			}),
+			ApiParam({
+				name: 'postId',
+				type: Number,
+			}),
+			ApiParam({
+				name: 'commentId',
+				type: Number,
+			}),
+			ApiResponse({
+				status: 204,
+				description: '삭제 완료',
+				type: Boolean,
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Location } from 'src/entities/locations.entity';
+import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
@@ -8,7 +9,7 @@ import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme])],
+	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment])],
 	controllers: [PostsController],
 	providers: [PostsService],
 })

--- a/src/modules/posts/posts.service.spec.ts
+++ b/src/modules/posts/posts.service.spec.ts
@@ -2,10 +2,12 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Location } from 'src/entities/locations.entity';
+import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
+import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
 import { MockPostThemesRepository } from 'test/mock/postThemes.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
@@ -33,6 +35,10 @@ describe('PostsService', () => {
 				{
 					provide: getRepositoryToken(PostTheme),
 					useClass: MockPostThemesRepository,
+				},
+				{
+					provide: getRepositoryToken(PostComment),
+					useClass: MockPostCommentsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/users/dto/comments-user-response.dto.ts
+++ b/src/modules/users/dto/comments-user-response.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CommentsUserResponseDto {
+	@ApiProperty({ example: 1, description: '사용자 id' })
+	readonly id: number;
+
+	@ApiProperty({ example: 'test', description: '사용자 닉네임' })
+	readonly nickname: string;
+
+	constructor({ id, nickname }) {
+		this.id = id;
+		this.nickname = nickname;
+	}
+}

--- a/test/mock/post-comments.mock.ts
+++ b/test/mock/post-comments.mock.ts
@@ -1,0 +1,14 @@
+export const mockPostComment = {
+	id: 1,
+	userId: 1,
+	postId: 1,
+	content: 'content',
+};
+
+export class MockPostCommentsRepository {
+	save = jest.fn().mockResolvedValue(mockPostComment);
+
+	async find() {
+		return mockPostComment;
+	}
+}

--- a/test/mock/post-comments.mock.ts
+++ b/test/mock/post-comments.mock.ts
@@ -3,6 +3,7 @@ export const mockPostComment = {
 	userId: 1,
 	postId: 1,
 	content: 'content',
+	isWriter: false,
 };
 
 export class MockPostCommentsRepository {


### PR DESCRIPTION
## 개요
- 커뮤니티 게시글의 댓글 관련 api를 구현했습니다.
  - 댓글 생성 api
  - 댓글 삭제 api
  - 댓글 목록 api
## 작업사항
- post-comment entity 생성
- comment api들
## 테스트
- 위에 명시한 api들 모두 테스트 부탁드려요.
- 더 추가되었으면 하는 응답 데이터들 있으면 말씀해주세요.