### PR TITLE
Feat: Create address of spots and modify location seed data

### DIFF
--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -2,6 +2,9 @@ import * as dotenv from 'dotenv';
 import { AdForm } from 'src/entities/ad-form.entity';
 import { AuthCode } from 'src/entities/auth-code.entity';
 import { Location } from 'src/entities/locations.entity';
+import { PostComment } from 'src/entities/post-comments.entity';
+import { PostTheme } from 'src/entities/post-themes.entity';
+import { Post } from 'src/entities/posts.entity';
 import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
 import { Spot } from 'src/entities/spots.entity';
@@ -22,7 +25,7 @@ const config = {
 	username: dbConfig.username,
 	password: dbConfig.password,
 	database: dbConfig.dbname,
-	entities: [User, AdForm, AuthCode, Theme, Location, Spot, SnsPost, TasteTheme, Rank],
+	entities: [User, AdForm, AuthCode, Theme, Location, Spot, SnsPost, TasteTheme, Rank, PostTheme, Post, PostComment],
 	seeds: [seedUrl + 'users.seed.ts', seedUrl + 'themes.seed.ts', seedUrl + 'locations.seed.ts'],
 	namingStrategy: new SnakeNamingStrategy(),
 	synchronize: process.env.NODE_ENV !== 'prod',

--- a/src/database/seeds/locations.seed.ts
+++ b/src/database/seeds/locations.seed.ts
@@ -9,28 +9,316 @@ const seedLocationDatas = [
 		localName: null,
 	},
 	{
+		metroName: '서울',
+		localName: '종로구',
+	},
+	{
+		metroName: '서울',
+		localName: '중구',
+	},
+	{
+		metroName: '서울',
+		localName: '용산구',
+	},
+	{
+		metroName: '서울',
+		localName: '성동구',
+	},
+	{
+		metroName: '서울',
+		localName: '광진구',
+	},
+	{
+		metroName: '서울',
+		localName: '동대문구',
+	},
+	{
+		metroName: '서울',
+		localName: '중랑구',
+	},
+	{
+		metroName: '서울',
+		localName: '성북구',
+	},
+	{
+		metroName: '서울',
+		localName: '강북구',
+	},
+	{
+		metroName: '서울',
+		localName: '도봉구',
+	},
+	{
+		metroName: '서울',
+		localName: '노원구',
+	},
+	{
+		metroName: '서울',
+		localName: '은평구',
+	},
+	{
+		metroName: '서울',
+		localName: '서대문구',
+	},
+	{
+		metroName: '서울',
+		localName: '마포구',
+	},
+	{
+		metroName: '서울',
+		localName: '양천구',
+	},
+	{
+		metroName: '서울',
+		localName: '강서구',
+	},
+	{
+		metroName: '서울',
+		localName: '구로구',
+	},
+	{
+		metroName: '서울',
+		localName: '금천구',
+	},
+	{
+		metroName: '서울',
+		localName: '영등포구',
+	},
+	{
+		metroName: '서울',
+		localName: '동작구',
+	},
+	{
+		metroName: '서울',
+		localName: '관악구',
+	},
+	{
+		metroName: '서울',
+		localName: '서초구',
+	},
+	{
+		metroName: '서울',
+		localName: '강남구',
+	},
+	{
+		metroName: '서울',
+		localName: '송파구',
+	},
+	{
+		metroName: '서울',
+		localName: '강동구',
+	},
+	{
 		metroName: '인천',
 		localName: null,
+	},
+	{
+		metroName: '인천',
+		localName: '중구',
+	},
+	{
+		metroName: '인천',
+		localName: '동구',
+	},
+	{
+		metroName: '인천',
+		localName: '미추홀구',
+	},
+	{
+		metroName: '인천',
+		localName: '연수구',
+	},
+	{
+		metroName: '인천',
+		localName: '남동구',
+	},
+	{
+		metroName: '인천',
+		localName: '부평구',
+	},
+	{
+		metroName: '인천',
+		localName: '계양구',
+	},
+	{
+		metroName: '인천',
+		localName: '서구',
+	},
+	{
+		metroName: '인천',
+		localName: '강화구',
+	},
+	{
+		metroName: '인천',
+		localName: '옹진구',
 	},
 	{
 		metroName: '부산',
 		localName: null,
 	},
 	{
+		metroName: '부산',
+		localName: '중구',
+	},
+	{
+		metroName: '부산',
+		localName: '서구',
+	},
+	{
+		metroName: '부산',
+		localName: '동구',
+	},
+	{
+		metroName: '부산',
+		localName: '영동구',
+	},
+	{
+		metroName: '부산',
+		localName: '부산진구',
+	},
+	{
+		metroName: '부산',
+		localName: '동래구',
+	},
+	{
+		metroName: '부산',
+		localName: '남구',
+	},
+	{
+		metroName: '부산',
+		localName: '북구',
+	},
+	{
+		metroName: '부산',
+		localName: '강서구',
+	},
+	{
+		metroName: '부산',
+		localName: '해운대구',
+	},
+	{
+		metroName: '부산',
+		localName: '사하구',
+	},
+	{
+		metroName: '부산',
+		localName: '금정구',
+	},
+	{
+		metroName: '부산',
+		localName: '연제구',
+	},
+	{
+		metroName: '부산',
+		localName: '수영구',
+	},
+	{
+		metroName: '부산',
+		localName: '사상구',
+	},
+	{
 		metroName: '대구',
 		localName: null,
+	},
+	{
+		metroName: '대구',
+		localName: '중구',
+	},
+	{
+		metroName: '대구',
+		localName: '동구',
+	},
+	{
+		metroName: '대구',
+		localName: '서구',
+	},
+	{
+		metroName: '대구',
+		localName: '남구',
+	},
+	{
+		metroName: '대구',
+		localName: '북구',
+	},
+	{
+		metroName: '대구',
+		localName: '수성구',
+	},
+	{
+		metroName: '대구',
+		localName: '달서구',
 	},
 	{
 		metroName: '대전',
 		localName: null,
 	},
 	{
+		metroName: '대전',
+		localName: '동구',
+	},
+	{
+		metroName: '대전',
+		localName: '중구',
+	},
+	{
+		metroName: '대전',
+		localName: '서구',
+	},
+	{
+		metroName: '대전',
+		localName: '유성구',
+	},
+	{
+		metroName: '대전',
+		localName: '대덕구',
+	},
+	{
 		metroName: '광주',
 		localName: null,
 	},
 	{
+		metroName: '광주',
+		localName: '동구',
+	},
+	{
+		metroName: '광주',
+		localName: '서구',
+	},
+	{
+		metroName: '광주',
+		localName: '남구',
+	},
+	{
+		metroName: '광주',
+		localName: '북구',
+	},
+	{
+		metroName: '광주',
+		localName: '광산구',
+	},
+	{
 		metroName: '울산',
 		localName: null,
+	},
+	{
+		metroName: '울산',
+		localName: '중구',
+	},
+	{
+		metroName: '울산',
+		localName: '남구',
+	},
+	{
+		metroName: '울산',
+		localName: '동구',
+	},
+	{
+		metroName: '울산',
+		localName: '북구',
+	},
+	{
+		metroName: '울산',
+		localName: '울주구',
 	},
 	{
 		metroName: '세종',
@@ -41,627 +329,647 @@ const seedLocationDatas = [
 		localName: null,
 	},
 	{
-		metroName: '경기도',
+		metroName: '제주',
+		localName: '제주시',
+	},
+	{
+		metroName: '제주',
+		localName: '서귀포시',
+	},
+	{
+		metroName: '경기',
 		localName: null,
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '고양시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '과천시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '광명시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '광주시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '구리시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '군포시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '김포시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '남양주시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '동두천시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '부천시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '성남시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '수원시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '시흥시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '안산시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '안성시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '안양시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '양주시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '오산시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '용인시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '의왕시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '의정부시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '이천시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '파주시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '평택시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '포천시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '하남시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '화성시',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '연천군',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '가평군',
 	},
 	{
-		metroName: '경기도',
+		metroName: '경기',
 		localName: '양평군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: null,
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '강릉시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '동해시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '삼척시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '속초시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '원주시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '춘천시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '태백시',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '홍천군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '횡성군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '영월군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '평창군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '정선군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '철원군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '화천군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '양구군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '인제군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '고성군',
 	},
 	{
-		metroName: '강원도',
+		metroName: '강원',
 		localName: '양양군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: null,
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '제천시',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '청주시',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '충주시',
 	},
 	{
-		metroName: '충청도',
-		localName: '계룡시',
-	},
-	{
-		metroName: '충청도',
-		localName: '공주시',
-	},
-	{
-		metroName: '충청도',
-		localName: '논산시',
-	},
-	{
-		metroName: '충청도',
-		localName: '당진시',
-	},
-	{
-		metroName: '충청도',
-		localName: '보령시',
-	},
-	{
-		metroName: '충청도',
-		localName: '서산시',
-	},
-	{
-		metroName: '충청도',
-		localName: '아산시',
-	},
-	{
-		metroName: '충청도',
-		localName: '천안시',
-	},
-	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '보은군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '옥천군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '영동군',
 	},
 	{
-		metroName: '충청도',
-		localName: '중평군',
+		metroName: '충북',
+		localName: '증평군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '진천군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '괴산군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '음성군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충북',
 		localName: '단양군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
+		localName: null,
+	},
+	{
+		metroName: '충남',
+		localName: '계룡시',
+	},
+	{
+		metroName: '충남',
+		localName: '공주시',
+	},
+	{
+		metroName: '충남',
+		localName: '논산시',
+	},
+	{
+		metroName: '충남',
+		localName: '당진시',
+	},
+	{
+		metroName: '충남',
+		localName: '보령시',
+	},
+	{
+		metroName: '충남',
+		localName: '서산시',
+	},
+	{
+		metroName: '충남',
+		localName: '아산시',
+	},
+	{
+		metroName: '충남',
+		localName: '천안시',
+	},
+	{
+		metroName: '충남',
 		localName: '금산군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '부여군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '서천군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '청양군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '홍성군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '예산군',
 	},
 	{
-		metroName: '충청도',
+		metroName: '충남',
 		localName: '태안군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: null,
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '경산시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '경주시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '구미시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '김천시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '문경시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '상주시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '안동시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '영주시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '영천시',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '포항시',
 	},
 	{
-		metroName: '경상도',
-		localName: '거제시',
-	},
-	{
-		metroName: '경상도',
-		localName: '김해시',
-	},
-	{
-		metroName: '경상도',
-		localName: '밀양시',
-	},
-	{
-		metroName: '경상도',
-		localName: '사천시',
-	},
-	{
-		metroName: '경상도',
-		localName: '양산시',
-	},
-	{
-		metroName: '경상도',
-		localName: '진주시',
-	},
-	{
-		metroName: '경상도',
-		localName: '창원시',
-	},
-	{
-		metroName: '경상도',
-		localName: '통영시',
-	},
-	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '군위군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '의성군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '청송군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '영양군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '영덕군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '청도군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '고령군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '성주군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '칠곡군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '예천군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '봉화군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '울진군',
 	},
 	{
-		metroName: '경상도',
+		metroName: '경북',
 		localName: '울릉군',
 	},
 	{
-		metroName: '경상도',
-		localName: '의령군',
-	},
-	{
-		metroName: '경상도',
-		localName: '함안군',
-	},
-	{
-		metroName: '경상도',
-		localName: '창녕군',
-	},
-	{
-		metroName: '경상도',
-		localName: '고성군',
-	},
-	{
-		metroName: '경상도',
-		localName: '남해군',
-	},
-	{
-		metroName: '경상도',
-		localName: '하동군',
-	},
-	{
-		metroName: '경상도',
-		localName: '산청군',
-	},
-	{
-		metroName: '경상도',
-		localName: '함양군',
-	},
-	{
-		metroName: '경상도',
-		localName: '거창군',
-	},
-	{
-		metroName: '경상도',
-		localName: '합천군',
-	},
-	{
-		metroName: '전라도',
+		metroName: '경남',
 		localName: null,
 	},
 	{
-		metroName: '전라도',
+		metroName: '경남',
+		localName: '거제시',
+	},
+	{
+		metroName: '경남',
+		localName: '김해시',
+	},
+	{
+		metroName: '경남',
+		localName: '밀양시',
+	},
+	{
+		metroName: '경남',
+		localName: '사천시',
+	},
+	{
+		metroName: '경남',
+		localName: '양산시',
+	},
+	{
+		metroName: '경남',
+		localName: '진주시',
+	},
+	{
+		metroName: '경남',
+		localName: '창원시',
+	},
+	{
+		metroName: '경남',
+		localName: '통영시',
+	},
+	{
+		metroName: '경남',
+		localName: '의령군',
+	},
+	{
+		metroName: '경남',
+		localName: '함안군',
+	},
+	{
+		metroName: '경남',
+		localName: '창녕군',
+	},
+	{
+		metroName: '경남',
+		localName: '고성군',
+	},
+	{
+		metroName: '경남',
+		localName: '남해군',
+	},
+	{
+		metroName: '경남',
+		localName: '하동군',
+	},
+	{
+		metroName: '경남',
+		localName: '산청군',
+	},
+	{
+		metroName: '경남',
+		localName: '함양군',
+	},
+	{
+		metroName: '경남',
+		localName: '거창군',
+	},
+	{
+		metroName: '경남',
+		localName: '합천군',
+	},
+	{
+		metroName: '전북',
+		localName: null,
+	},
+	{
+		metroName: '전북',
 		localName: '군산시',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '김제시',
 	},
 	{
-		metroName: '전라도',
-		localName: '낙원시',
+		metroName: '전북',
+		localName: '남원시',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '익산시',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '전주시',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '정읍시',
 	},
 	{
-		metroName: '전라도',
-		localName: '광양시',
-	},
-	{
-		metroName: '전라도',
-		localName: '나주시',
-	},
-	{
-		metroName: '전라도',
-		localName: '목포시',
-	},
-	{
-		metroName: '전라도',
-		localName: '순천시',
-	},
-	{
-		metroName: '전라도',
-		localName: '여수시',
-	},
-	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '완주군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '진안군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '무주군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '장수군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '임실군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '순창군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '고창군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전북',
 		localName: '부안군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
+		localName: null,
+	},
+	{
+		metroName: '전남',
+		localName: '광양시',
+	},
+	{
+		metroName: '전남',
+		localName: '나주시',
+	},
+	{
+		metroName: '전남',
+		localName: '목포시',
+	},
+	{
+		metroName: '전남',
+		localName: '순천시',
+	},
+	{
+		metroName: '전남',
+		localName: '여수시',
+	},
+	{
+		metroName: '전남',
 		localName: '담양군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '곡성군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '구례군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '고흥군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '보성군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '화순군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '장흥군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '강진군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '해남군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '영암군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '무안군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '함평군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '영광군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '장성군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '완도군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '진도군',
 	},
 	{
-		metroName: '전라도',
+		metroName: '전남',
 		localName: '신안군',
 	},
 ];

--- a/src/database/seeds/locations.seed.ts
+++ b/src/database/seeds/locations.seed.ts
@@ -146,11 +146,11 @@ const seedLocationDatas = [
 	},
 	{
 		metroName: '인천',
-		localName: '강화구',
+		localName: '강화군',
 	},
 	{
 		metroName: '인천',
-		localName: '옹진구',
+		localName: '옹진군',
 	},
 	{
 		metroName: '부산',
@@ -170,7 +170,7 @@ const seedLocationDatas = [
 	},
 	{
 		metroName: '부산',
-		localName: '영동구',
+		localName: '영도구',
 	},
 	{
 		metroName: '부산',
@@ -217,6 +217,10 @@ const seedLocationDatas = [
 		localName: '사상구',
 	},
 	{
+		metroName: '부산',
+		localName: '기장군',
+	},
+	{
 		metroName: '대구',
 		localName: null,
 	},
@@ -247,6 +251,10 @@ const seedLocationDatas = [
 	{
 		metroName: '대구',
 		localName: '달서구',
+	},
+	{
+		metroName: '대구',
+		localName: '달성군',
 	},
 	{
 		metroName: '대전',
@@ -318,7 +326,7 @@ const seedLocationDatas = [
 	},
 	{
 		metroName: '울산',
-		localName: '울주구',
+		localName: '울주군',
 	},
 	{
 		metroName: '세종',
@@ -447,6 +455,10 @@ const seedLocationDatas = [
 	{
 		metroName: '경기',
 		localName: '화성시',
+	},
+	{
+		metroName: '경기',
+		localName: '여주시',
 	},
 	{
 		metroName: '경기',

--- a/src/entities/spots.entity.ts
+++ b/src/entities/spots.entity.ts
@@ -43,6 +43,10 @@ export class Spot extends CommonEntity {
 	})
 	geom: Geometry;
 
+	@IsString()
+	@Column({ type: 'varchar', length: 30, nullable: false })
+	address: string;
+
 	@IsNumber()
 	@Column({ type: 'smallint', nullable: true })
 	rank: number | null;

--- a/src/modules/spots/dto/save-request.dto.ts
+++ b/src/modules/spots/dto/save-request.dto.ts
@@ -11,6 +11,10 @@ export class SaveRequestDto {
 	readonly localName: string | null;
 
 	@IsString()
+	@ApiProperty({ example: '경상북도 경주시 남산동', description: '여행지 상세주소' })
+	readonly address: string;
+
+	@IsString()
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
 
@@ -49,6 +53,7 @@ export class SaveRequestDto {
 	constructor({
 		metroName,
 		localName,
+		address,
 		name,
 		latitude,
 		longitude,
@@ -61,6 +66,7 @@ export class SaveRequestDto {
 	}) {
 		this.metroName = metroName;
 		this.localName = localName;
+		this.address = address;
 		this.name = name;
 		this.latitude = latitude;
 		this.longitude = longitude;

--- a/src/modules/spots/dto/search-response.dto.ts
+++ b/src/modules/spots/dto/search-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
-import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
-
 export class SearchResponseDto {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -12,12 +10,13 @@ export class SearchResponseDto {
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
+	@IsString()
+	@ApiProperty({ example: '경상북도 경주시 남산동', description: '여행지 상세주소' })
+	readonly address: string;
 
-	constructor({ id, name, location }) {
+	constructor({ id, name, address }) {
 		this.id = id;
 		this.name = name;
-		this.location = new LocationResponseDto(location);
+		this.address = address;
 	}
 }

--- a/src/modules/spots/dto/spot-request.dto.ts
+++ b/src/modules/spots/dto/spot-request.dto.ts
@@ -11,6 +11,10 @@ export class SpotRequestDto {
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
 
+	@IsString()
+	@ApiProperty({ example: '경상북도 경주시 남산동', description: '여행지 상세주소' })
+	readonly address: string;
+
 	@IsNumber()
 	@ApiProperty({ example: 37.253452, description: '위도' })
 	readonly latitude: number;
@@ -35,9 +39,10 @@ export class SpotRequestDto {
 	@ApiProperty({ example: 100, description: 'sns 게시글 좋아요 수' })
 	readonly snsPostLikeNumber: number;
 
-	constructor({ locationId, name, latitude, longitude, rank }) {
+	constructor({ locationId, name, address, latitude, longitude, rank }) {
 		this.locationId = locationId;
 		this.name = name;
+		this.address = address;
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.geom = `(${latitude.toString()},${longitude.toString()})`;

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -146,6 +146,7 @@ export class SpotsService {
 					arr.findIndex(
 						(item) =>
 							item.name === character.name &&
+							item.address === character.address &&
 							item.metroName === character.metroName &&
 							item.localName === character.localName &&
 							item.latitude === character.latitude &&
@@ -170,6 +171,7 @@ export class SpotsService {
 					new SpotRequestDto({
 						locationId: oneLocation.id,
 						name: spot.name,
+						address: spot.address,
 						latitude: spot.latitude,
 						longitude: spot.longitude,
 						rank: spot.rank,
@@ -316,7 +318,6 @@ export class SpotsService {
 		try {
 			let searchSpots = this.spotsRepository
 				.createQueryBuilder('spot')
-				.leftJoinAndSelect('spot.location', 'location')
 				.orderBy(`spot.${searchRequest.sorter}`, 'ASC');
 			if (searchRequest.word) {
 				searchSpots = searchSpots.where('spot.name Like :name', { name: `%${searchRequest.word}%` });
@@ -327,7 +328,9 @@ export class SpotsService {
 				const localsIds = Array.from(allMetros).flatMap(({ id }) => [id]);
 				locationIds = [...new Set(locationIds.concat(localsIds))];
 
-				searchSpots = searchSpots.andWhere('location.id IN (:...locationIds)', { locationIds: locationIds });
+				searchSpots = searchSpots
+					.leftJoinAndSelect('spot.location', 'location')
+					.andWhere('location.id IN (:...locationIds)', { locationIds: locationIds });
 			}
 			if (searchRequest.themeIds) {
 				searchSpots = searchSpots
@@ -342,17 +345,7 @@ export class SpotsService {
 				.getMany();
 
 			const totalPage = Math.ceil(totalPageSpots.length / searchRequest.take);
-			const spots = Array.from(responseSpots).map(
-				(spot) =>
-					new SearchResponseDto({
-						...spot,
-						location: new LocationResponseDto({
-							id: spot.location.id,
-							metroName: spot.location.metroName,
-							localName: spot.location.localName,
-						}),
-					}),
-			);
+			const spots = Array.from(responseSpots).map((spot) => new SearchResponseDto(spot));
 			return new SearchPageResponseDto({ totalPage: totalPage, spots: spots });
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);


### PR DESCRIPTION
## 작업사항
- Locaiton Seed data 수정
- Spot entity에 address 추가
- ML에서 address 추가로 받아와서 spot에 저장
- spot search page에서 목록 받아올 때, location metro_name, local_name 대신에 adress로 수정

## 테스트
- location seed  잘 들어가는지 확인
- spot entity에 address 추가 되었는지 확인
- post로 spot넣을 때 잘 들어가지는 지 확인
- search spot에서 전체 목록 (id, name, address) 받아와지는 지 확인