### PR TITLE
Feat: User log api (click, wish, like)

### DIFF
--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -1,13 +1,4 @@
 import * as dotenv from 'dotenv';
-import { AdForm } from 'src/entities/ad-form.entity';
-import { AuthCode } from 'src/entities/auth-code.entity';
-import { Location } from 'src/entities/locations.entity';
-import { Rank } from 'src/entities/rank.entity';
-import { SnsPost } from 'src/entities/sns-posts.entity';
-import { Spot } from 'src/entities/spots.entity';
-import { TasteTheme } from 'src/entities/taste-themes.entity';
-import { Theme } from 'src/entities/theme.entity';
-import { User } from 'src/entities/users.entity';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 import { databaseConfig } from '../config/config.constant';
@@ -22,7 +13,7 @@ const config = {
 	username: dbConfig.username,
 	password: dbConfig.password,
 	database: dbConfig.dbname,
-	entities: [User, AdForm, AuthCode, Theme, Location, Spot, SnsPost, TasteTheme, Rank],
+	entities: ['src/entities/*.entity.ts'],
 	seeds: [seedUrl + 'users.seed.ts', seedUrl + 'themes.seed.ts', seedUrl + 'locations.seed.ts'],
 	namingStrategy: new SnakeNamingStrategy(),
 	synchronize: process.env.NODE_ENV !== 'prod',

--- a/src/entities/auth-code.entity.ts
+++ b/src/entities/auth-code.entity.ts
@@ -6,9 +6,6 @@ import { CommonEntity } from './common.entity';
 
 @Entity()
 export class AuthCode extends CommonEntity {
-	// type = SignUp (회원가입을 위한 인증코드)
-	// type = FindPw (비밀번호 찾기를 위한 인증코드)
-
 	@IsEmail()
 	@IsNotEmpty()
 	@Column({ type: 'varchar', nullable: false, unique: true })

--- a/src/entities/click-posts.entity.ts
+++ b/src/entities/click-posts.entity.ts
@@ -1,0 +1,31 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Post } from './posts.entity';
+import { User } from './users.entity';
+
+@Entity()
+export class ClickPost extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.clickPosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'post_id' })
+	postId: number;
+
+	@ManyToOne(() => Post, (post: Post) => post.clickPosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'post_id', referencedColumnName: 'id' }])
+	post: Post;
+}

--- a/src/entities/click-spots.entity.ts
+++ b/src/entities/click-spots.entity.ts
@@ -1,0 +1,31 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Spot } from './spots.entity';
+import { User } from './users.entity';
+
+@Entity()
+export class ClickSpot extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.clickSpots, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'spot_id' })
+	spotId: number;
+
+	@ManyToOne(() => Spot, (spot: Spot) => spot.clickSpots, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'spot_id', referencedColumnName: 'id' }])
+	spot: Spot;
+}

--- a/src/entities/like-posts.entity.ts
+++ b/src/entities/like-posts.entity.ts
@@ -1,0 +1,31 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Post } from './posts.entity';
+import { User } from './users.entity';
+
+@Entity()
+export class LikePost extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.likePosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'post_id' })
+	postId: number;
+
+	@ManyToOne(() => Post, (post: Post) => post.likePosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'post_id', referencedColumnName: 'id' }])
+	post: Post;
+}

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { ClickPost } from './click-posts.entity';
 
 import { CommonEntity } from './common.entity';
+import { LikePost } from './like-posts.entity';
 import { Location } from './locations.entity';
 import { PostComment } from './post-comments.entity';
 import { PostTheme } from './post-themes.entity';
@@ -68,4 +69,9 @@ export class Post extends CommonEntity {
 		cascade: true,
 	})
 	clickPosts: ClickPost[];
+
+	@OneToMany(() => LikePost, (likePost: LikePost) => likePost.post, {
+		cascade: true,
+	})
+	likePosts: LikePost[];
 }

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -1,5 +1,6 @@
 import { IsArray, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { ClickPost } from './click-posts.entity';
 
 import { CommonEntity } from './common.entity';
 import { Location } from './locations.entity';
@@ -62,4 +63,9 @@ export class Post extends CommonEntity {
 		eager: true,
 	})
 	postComments: PostComment[];
+
+	@OneToMany(() => ClickPost, (clickPosts: ClickPost) => clickPosts.post, {
+		cascade: true,
+	})
+	clickPosts: ClickPost[];
 }

--- a/src/entities/spots.entity.ts
+++ b/src/entities/spots.entity.ts
@@ -1,6 +1,7 @@
 import { IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Geometry } from 'geojson';
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { ClickSpot } from './click-spots.entity';
 
 import { CommonEntity } from './common.entity';
 import { Location } from './locations.entity';
@@ -65,4 +66,10 @@ export class Spot extends CommonEntity {
 		cascade: true,
 	})
 	rankings: Rank[];
+
+	@OneToMany(() => ClickSpot, (clickSpot: ClickSpot) => clickSpot.spot, {
+		cascade: true,
+		eager: true,
+	})
+	clickSpots: ClickSpot[];
 }

--- a/src/entities/spots.entity.ts
+++ b/src/entities/spots.entity.ts
@@ -7,6 +7,7 @@ import { CommonEntity } from './common.entity';
 import { Location } from './locations.entity';
 import { Rank } from './rank.entity';
 import { SnsPost } from './sns-posts.entity';
+import { WishSpot } from './wish-spots.entity';
 
 @Entity()
 export class Spot extends CommonEntity {
@@ -72,4 +73,9 @@ export class Spot extends CommonEntity {
 		eager: true,
 	})
 	clickSpots: ClickSpot[];
+
+	@OneToMany(() => WishSpot, (wishSpot: WishSpot) => wishSpot.spot, {
+		cascade: true,
+	})
+	wishSpots: WishSpot[];
 }

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -2,6 +2,7 @@ import { IsBoolean, IsEmail, IsNotEmpty, IsNumber, IsString, Length } from 'clas
 import { Column, Entity, OneToMany } from 'typeorm';
 
 import { UserType } from 'src/types/users.types';
+import { ClickSpot } from './click-spots.entity';
 import { CommonEntity } from './common.entity';
 import { PostComment } from './post-comments.entity';
 import { Post } from './posts.entity';
@@ -54,7 +55,11 @@ export class User extends CommonEntity {
 
 	@OneToMany(() => PostComment, (postComment: PostComment) => postComment.user, {
 		cascade: true,
-		eager: true,
 	})
 	postComments: PostComment[];
+
+	@OneToMany(() => ClickSpot, (clickSpot: ClickSpot) => clickSpot.user, {
+		cascade: true,
+	})
+	clickSpots: ClickSpot[];
 }

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -8,6 +8,7 @@ import { CommonEntity } from './common.entity';
 import { PostComment } from './post-comments.entity';
 import { Post } from './posts.entity';
 import { TasteTheme } from './taste-themes.entity';
+import { WishSpot } from './wish-spots.entity';
 
 @Entity()
 export class User extends CommonEntity {
@@ -64,8 +65,13 @@ export class User extends CommonEntity {
 	})
 	clickSpots: ClickSpot[];
 
-	@OneToMany(() => ClickPost, (clickPosts: ClickPost) => clickPosts.user, {
+	@OneToMany(() => ClickPost, (clickPost: ClickPost) => clickPost.user, {
 		cascade: true,
 	})
 	clickPosts: ClickPost[];
+
+	@OneToMany(() => WishSpot, (wishSpot: WishSpot) => wishSpot.user, {
+		cascade: true,
+	})
+	wishSpots: WishSpot[];
 }

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -2,6 +2,7 @@ import { IsBoolean, IsEmail, IsNotEmpty, IsNumber, IsString, Length } from 'clas
 import { Column, Entity, OneToMany } from 'typeorm';
 
 import { UserType } from 'src/types/users.types';
+import { ClickPost } from './click-posts.entity';
 import { ClickSpot } from './click-spots.entity';
 import { CommonEntity } from './common.entity';
 import { PostComment } from './post-comments.entity';
@@ -62,4 +63,9 @@ export class User extends CommonEntity {
 		cascade: true,
 	})
 	clickSpots: ClickSpot[];
+
+	@OneToMany(() => ClickPost, (clickPosts: ClickPost) => clickPosts.user, {
+		cascade: true,
+	})
+	clickPosts: ClickPost[];
 }

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -5,6 +5,7 @@ import { UserType } from 'src/types/users.types';
 import { ClickPost } from './click-posts.entity';
 import { ClickSpot } from './click-spots.entity';
 import { CommonEntity } from './common.entity';
+import { LikePost } from './like-posts.entity';
 import { PostComment } from './post-comments.entity';
 import { Post } from './posts.entity';
 import { TasteTheme } from './taste-themes.entity';
@@ -74,4 +75,9 @@ export class User extends CommonEntity {
 		cascade: true,
 	})
 	wishSpots: WishSpot[];
+
+	@OneToMany(() => LikePost, (likePost: LikePost) => likePost.user, {
+		cascade: true,
+	})
+	likePosts: LikePost[];
 }

--- a/src/entities/wish-spots.entity.ts
+++ b/src/entities/wish-spots.entity.ts
@@ -1,0 +1,32 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Spot } from './spots.entity';
+import { User } from './users.entity';
+
+@Entity()
+@Unique(['userId', 'spotId'])
+export class WishSpot extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.wishSpots, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'spot_id' })
+	spotId: number;
+
+	@ManyToOne(() => Spot, (spot: Spot) => spot.wishSpots, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'spot_id', referencedColumnName: 'id' }])
+	spot: Spot;
+}

--- a/src/modules/posts/dto/get-posts-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-response.dto.ts
@@ -30,6 +30,10 @@ export class GetPostsResponseDto {
 	@ApiProperty({ example: '2022-11-11', description: '작성 날짜' })
 	readonly createdAt: Date;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '게시글 조회수' })
+	readonly views: number;
+
 	@ApiProperty({ description: '작성자 정보' })
 	readonly user: CommentsUserResponseDto;
 
@@ -41,13 +45,14 @@ export class GetPostsResponseDto {
 	@ApiProperty({ description: '테마 정보' })
 	readonly themes: ThemeResponseDto[];
 
-	constructor({ id, title, content, photo_urls, isWriter, created_at, user, location, themes }) {
+	constructor({ id, title, content, photoUrls, isWriter, createdAt, views, user, location, themes }) {
 		this.id = id;
 		this.title = title;
 		this.content = content;
-		this.photoUrls = photo_urls;
+		this.photoUrls = photoUrls;
 		this.isWriter = isWriter;
-		this.createdAt = created_at;
+		this.createdAt = createdAt;
+		this.views = views;
 		this.user = user;
 		this.location = location;
 		this.themes = themes;

--- a/src/modules/posts/dto/get-posts-response.dto.ts
+++ b/src/modules/posts/dto/get-posts-response.dto.ts
@@ -34,6 +34,14 @@ export class GetPostsResponseDto {
 	@ApiProperty({ example: 10, description: '게시글 조회수' })
 	readonly views: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '게시글 좋아요 개수' })
+	readonly likes: number;
+
+	@IsBoolean()
+	@ApiProperty({ example: false, description: '게시글 좋아요 여부' })
+	readonly isLike: boolean;
+
 	@ApiProperty({ description: '작성자 정보' })
 	readonly user: CommentsUserResponseDto;
 
@@ -45,7 +53,7 @@ export class GetPostsResponseDto {
 	@ApiProperty({ description: '테마 정보' })
 	readonly themes: ThemeResponseDto[];
 
-	constructor({ id, title, content, photoUrls, isWriter, createdAt, views, user, location, themes }) {
+	constructor({ id, title, content, photoUrls, isWriter, createdAt, views, likes, isLike, user, location, themes }) {
 		this.id = id;
 		this.title = title;
 		this.content = content;
@@ -53,6 +61,8 @@ export class GetPostsResponseDto {
 		this.isWriter = isWriter;
 		this.createdAt = createdAt;
 		this.views = views;
+		this.likes = likes;
+		this.isLike = isLike;
 		this.user = user;
 		this.location = location;
 		this.themes = themes;

--- a/src/modules/posts/dto/main-posts-response.dto.ts
+++ b/src/modules/posts/dto/main-posts-response.dto.ts
@@ -19,6 +19,10 @@ export class MainPostsResponseDto {
 	@ApiProperty({ example: '2022-11-11', description: '게시글 작성 날짜' })
 	readonly createdAt: Date;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '게시글 조회수' })
+	readonly views: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
@@ -26,11 +30,12 @@ export class MainPostsResponseDto {
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })
 	readonly photoUrls: string[];
 
-	constructor({ id, title, user, createdAt, location, photoUrls }) {
+	constructor({ id, title, user, createdAt, views, location, photoUrls }) {
 		this.id = id;
 		this.title = title;
 		this.user = user;
 		this.createdAt = createdAt;
+		this.views = views;
 		this.location = new LocationResponseDto(location);
 		this.photoUrls = photoUrls;
 	}

--- a/src/modules/posts/dto/main-posts-response.dto.ts
+++ b/src/modules/posts/dto/main-posts-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsDateString, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsDateString, IsNumber, IsString } from 'class-validator';
 import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 import { CommentsUserResponseDto } from 'src/modules/users/dto/comments-user-response.dto';
 
@@ -23,6 +23,14 @@ export class MainPostsResponseDto {
 	@ApiProperty({ example: 10, description: '게시글 조회수' })
 	readonly views: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '게시글 좋아요 개수' })
+	readonly likes: number;
+
+	@IsBoolean()
+	@ApiProperty({ example: false, description: '게시글 좋아요 여부' })
+	readonly isLike: boolean;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
@@ -30,12 +38,14 @@ export class MainPostsResponseDto {
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })
 	readonly photoUrls: string[];
 
-	constructor({ id, title, user, createdAt, views, location, photoUrls }) {
+	constructor({ id, title, user, createdAt, views, likes, isLike, location, photoUrls }) {
 		this.id = id;
 		this.title = title;
 		this.user = user;
 		this.createdAt = createdAt;
 		this.views = views;
+		this.likes = likes;
+		this.isLike = isLike;
 		this.location = new LocationResponseDto(location);
 		this.photoUrls = photoUrls;
 	}

--- a/src/modules/posts/posts.controller.spec.ts
+++ b/src/modules/posts/posts.controller.spec.ts
@@ -1,11 +1,13 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { ClickPost } from 'src/entities/click-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
@@ -41,6 +43,10 @@ describe('PostsController', () => {
 				{
 					provide: getRepositoryToken(PostComment),
 					useClass: MockPostCommentsRepository,
+				},
+				{
+					provide: getRepositoryToken(ClickPost),
+					useClass: MockClickPostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.controller.spec.ts
+++ b/src/modules/posts/posts.controller.spec.ts
@@ -2,12 +2,14 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ClickPost } from 'src/entities/click-posts.entity';
+import { LikePost } from 'src/entities/like-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
+import { MockLikePostsRepository } from 'test/mock/like-posts.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
@@ -48,6 +50,10 @@ describe('PostsController', () => {
 				{
 					provide: getRepositoryToken(ClickPost),
 					useClass: MockClickPostsRepository,
+				},
+				{
+					provide: getRepositoryToken(LikePost),
+					useClass: MockLikePostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -62,8 +62,8 @@ export class PostsController {
 
 	@Get()
 	@ApiDocs.getMainPost('커뮤니티 메인 게시판(단어 검색, 정렬, 필터링, 페이지네이션)')
-	async getMainPost(@Query() searchRequest: MainPostsRequestDto) {
-		return await this.postsService.getMainPost(searchRequest);
+	async getMainPost(@AuthUser() userData, @Query() searchRequest: MainPostsRequestDto) {
+		return await this.postsService.getMainPost(userData.id, searchRequest);
 	}
 
 	@Patch(':postId')
@@ -133,5 +133,12 @@ export class PostsController {
 		@Param('commentId') commentId: number,
 	) {
 		return await this.postsService.deletePostsComment(userData.id, postId, commentId);
+	}
+
+	@Post(':postId/likes/:isLike')
+	@ApiDocs.likePost('커뮤니티 게시글 좋아요')
+	async likePost(@AuthUser() userData, @Param('postId') postId: number, @Param('isLike') isLike: number) {
+		const isLikeBool = isLike === 1 ? true : false;
+		return await this.postsService.likePost(userData.id, postId, isLikeBool);
 	}
 }

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -17,12 +17,12 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthUser } from 'src/decorators/auth.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { MainPostsRequestDto } from './dto/main-posts-request.dto';
 import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
 import { PostsRequestDto } from './dto/posts-request.dto';
 import { UpdatePostsRequestDto } from './dto/update-posts-request.dto';
 import { ApiDocs } from './posts.docs';
 import { PostsService } from './posts.service';
-import { MainPostsRequestDto } from './dto/main-posts-request.dto';
 
 @Controller('posts')
 @ApiTags('posts - 커뮤니티 게시글 정보')
@@ -58,6 +58,12 @@ export class PostsController {
 		@Body() postData: PostsRequestDto,
 	) {
 		return await this.postsService.createPost(userData.id, photos, postData);
+	}
+
+	@Get()
+	@ApiDocs.getMainPost('커뮤니티 메인 게시판(단어 검색, 정렬, 필터링, 페이지네이션)')
+	async getMainPost(@Query() searchRequest: MainPostsRequestDto) {
+		return await this.postsService.getMainPost(searchRequest);
 	}
 
 	@Patch(':postId')
@@ -127,11 +133,5 @@ export class PostsController {
 		@Param('commentId') commentId: number,
 	) {
 		return await this.postsService.deletePostsComment(userData.id, postId, commentId);
-	}
-
-	@Get()
-	@ApiDocs.getMainPost('커뮤니티 메인 게시판(단어 검색, 정렬, 필터링, 페이지네이션)')
-	async getMainPost(@Query() searchRequest: MainPostsRequestDto) {
-		return await this.postsService.getMainPost(searchRequest);
 	}
 }

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -200,6 +200,28 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	likePost(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '커뮤니티 게시글 좋아요',
+			}),
+			ApiParam({
+				name: 'postId',
+				type: Number,
+			}),
+			ApiParam({
+				name: 'isLike',
+				type: Number,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 	getMainPost(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClickPost } from 'src/entities/click-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
@@ -9,7 +10,7 @@ import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment])],
+	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment, ClickPost])],
 	controllers: [PostsController],
 	providers: [PostsService],
 })

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClickPost } from 'src/entities/click-posts.entity';
+import { LikePost } from 'src/entities/like-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
@@ -10,7 +11,7 @@ import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment, ClickPost])],
+	imports: [TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment, ClickPost, LikePost])],
 	controllers: [PostsController],
 	providers: [PostsService],
 })

--- a/src/modules/posts/posts.service.spec.ts
+++ b/src/modules/posts/posts.service.spec.ts
@@ -2,12 +2,14 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ClickPost } from 'src/entities/click-posts.entity';
+import { LikePost } from 'src/entities/like-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
+import { MockLikePostsRepository } from 'test/mock/like-posts.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
@@ -45,6 +47,10 @@ describe('PostsService', () => {
 				{
 					provide: getRepositoryToken(ClickPost),
 					useClass: MockClickPostsRepository,
+				},
+				{
+					provide: getRepositoryToken(LikePost),
+					useClass: MockLikePostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.service.spec.ts
+++ b/src/modules/posts/posts.service.spec.ts
@@ -1,11 +1,13 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { ClickPost } from 'src/entities/click-posts.entity';
 import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
@@ -39,6 +41,10 @@ describe('PostsService', () => {
 				{
 					provide: getRepositoryToken(PostComment),
 					useClass: MockPostCommentsRepository,
+				},
+				{
+					provide: getRepositoryToken(ClickPost),
+					useClass: MockClickPostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/ranks/dto/ranking-list-response.dto.ts
+++ b/src/modules/ranks/dto/ranking-list-response.dto.ts
@@ -20,14 +20,19 @@ export class RankingListResponseDto {
 	@ApiProperty({ example: -1, description: '순위 변동' })
 	readonly variance: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 조회수' })
+	readonly views: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
-	constructor({ id, name, rank, variance, location }) {
+	constructor({ id, name, rank, variance, views, location }) {
 		this.id = id;
 		this.name = name;
 		this.rank = rank;
 		this.variance = variance;
+		this.views = views;
 		this.location = new LocationResponseDto(location);
 	}
 }

--- a/src/modules/ranks/dto/ranking-list-response.dto.ts
+++ b/src/modules/ranks/dto/ranking-list-response.dto.ts
@@ -24,15 +24,20 @@ export class RankingListResponseDto {
 	@ApiProperty({ example: 10, description: '여행지 조회수' })
 	readonly views: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 찜하기 개수' })
+	readonly wishes: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
-	constructor({ id, name, rank, variance, views, location }) {
+	constructor({ id, name, rank, variance, views, wishes, location }) {
 		this.id = id;
 		this.name = name;
 		this.rank = rank;
 		this.variance = variance;
 		this.views = views;
+		this.wishes = wishes;
 		this.location = new LocationResponseDto(location);
 	}
 }

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -4,12 +4,12 @@ import { Repository } from 'typeorm';
 
 import { Rank } from 'src/entities/rank.entity';
 import { Spot } from 'src/entities/spots.entity';
+import { LocationResponseDto } from '../filters/dto/location-response.dto';
+import { RankingListResponseDto } from './dto/ranking-list-response.dto';
+import { RankingMapResponseDto } from './dto/ranking-map-response.dto';
 import { RankingRequestDto } from './dto/ranking-request.dto';
 import { RanksRecordRequestDto } from './dto/ranks-record-request.dto';
 import { RanksUpdateRequestDto } from './dto/ranks-update-request.dto';
-import { RankingListResponseDto } from './dto/ranking-list-response.dto';
-import { RankingMapResponseDto } from './dto/ranking-map-response.dto';
-import { LocationResponseDto } from '../filters/dto/location-response.dto';
 
 @Injectable()
 export class RanksService {
@@ -56,6 +56,7 @@ export class RanksService {
 				.createQueryBuilder('spot')
 				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
+				.innerJoinAndSelect('spot.clickSpots', 'clickSpots')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.select('spot.id AS id, spot.name AS name')
 				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
@@ -85,6 +86,7 @@ export class RanksService {
 					...spot,
 					rank: spot.after_rank,
 					variance: variance,
+					views: spot.clickSpots.length,
 					location: new LocationResponseDto({
 						id: spot.location_id,
 						metroName: spot.metro,

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -57,6 +57,7 @@ export class RanksService {
 				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.innerJoinAndSelect('spot.clickSpots', 'clickSpots')
+				.innerJoinAndSelect('spot.wishSpots', 'wishSpots')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.select('spot.id AS id, spot.name AS name')
 				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
@@ -87,6 +88,7 @@ export class RanksService {
 					rank: spot.after_rank,
 					variance: variance,
 					views: spot.clickSpots.length,
+					wishes: spot.wishSpots.length,
 					location: new LocationResponseDto({
 						id: spot.location_id,
 						metroName: spot.metro,

--- a/src/modules/recommendations/recommendations.service.ts
+++ b/src/modules/recommendations/recommendations.service.ts
@@ -80,6 +80,7 @@ export class RecommendationsService {
 				new SearchResponseDto({
 					...listRecommendationSpot,
 					views: listRecommendationSpot.clickSpots.length,
+					wishes: listRecommendationSpot.wishSpots.length,
 					location: new LocationResponseDto({
 						id: listRecommendationSpot.location.id,
 						metroName: listRecommendationSpot.location.metroName,
@@ -202,6 +203,7 @@ export class RecommendationsService {
 				.createQueryBuilder('spot')
 				.leftJoinAndSelect('spot.location', 'location')
 				.leftJoinAndSelect('spot.clickSpots', 'clickSpots')
+				.leftJoinAndSelect('spot.wishSpots', 'wishSpots')
 				.where('spot.id IN (:...spotIds)', { spotIds })
 				.getMany();
 

--- a/src/modules/spots/dto/detail-spot-response.dto.ts
+++ b/src/modules/spots/dto/detail-spot-response.dto.ts
@@ -24,6 +24,10 @@ export class DetailSpotResponseDto<S, N> {
 	@ApiProperty({ example: 1, description: '호감도' })
 	readonly snsPostLikeNumber: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 조회수' })
+	readonly views: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
@@ -35,12 +39,13 @@ export class DetailSpotResponseDto<S, N> {
 	@ApiProperty({ isArray: true, example: '여행지 주변 시설' })
 	readonly neaybyFacility: N[];
 
-	constructor({ id, name, latitude, longitude, snsPostLikeNumber, location, detailSnsPost, neaybyFacility }) {
+	constructor({ id, name, latitude, longitude, snsPostLikeNumber, views, location, detailSnsPost, neaybyFacility }) {
 		this.id = id;
 		this.name = name;
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.snsPostLikeNumber = snsPostLikeNumber;
+		this.views = views;
 		this.location = new LocationResponseDto(location);
 		this.detailSnsPost = detailSnsPost;
 		this.neaybyFacility = neaybyFacility;

--- a/src/modules/spots/dto/detail-spot-response.dto.ts
+++ b/src/modules/spots/dto/detail-spot-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsNumber, IsString } from 'class-validator';
 
 import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 
@@ -28,6 +28,14 @@ export class DetailSpotResponseDto<S, N> {
 	@ApiProperty({ example: 10, description: '여행지 조회수' })
 	readonly views: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 찜하기 개수' })
+	readonly wishes: number;
+
+	@IsBoolean()
+	@ApiProperty({ example: false, description: '여행지 찜하기 여부' })
+	readonly isWish: boolean;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
@@ -39,13 +47,27 @@ export class DetailSpotResponseDto<S, N> {
 	@ApiProperty({ isArray: true, example: '여행지 주변 시설' })
 	readonly neaybyFacility: N[];
 
-	constructor({ id, name, latitude, longitude, snsPostLikeNumber, views, location, detailSnsPost, neaybyFacility }) {
+	constructor({
+		id,
+		name,
+		latitude,
+		longitude,
+		snsPostLikeNumber,
+		views,
+		wishes,
+		isWish,
+		location,
+		detailSnsPost,
+		neaybyFacility,
+	}) {
 		this.id = id;
 		this.name = name;
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.snsPostLikeNumber = snsPostLikeNumber;
 		this.views = views;
+		this.wishes = wishes;
+		this.isWish = isWish;
 		this.location = new LocationResponseDto(location);
 		this.detailSnsPost = detailSnsPost;
 		this.neaybyFacility = neaybyFacility;

--- a/src/modules/spots/dto/search-response.dto.ts
+++ b/src/modules/spots/dto/search-response.dto.ts
@@ -12,12 +12,17 @@ export class SearchResponseDto {
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 조회수' })
+	readonly views: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
-	constructor({ id, name, location }) {
+	constructor({ id, name, views, location }) {
 		this.id = id;
 		this.name = name;
+		this.views = views;
 		this.location = new LocationResponseDto(location);
 	}
 }

--- a/src/modules/spots/dto/search-response.dto.ts
+++ b/src/modules/spots/dto/search-response.dto.ts
@@ -16,13 +16,18 @@ export class SearchResponseDto {
 	@ApiProperty({ example: 10, description: '여행지 조회수' })
 	readonly views: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 10, description: '여행지 찜하기 개수' })
+	readonly wishes: number;
+
 	@ApiProperty({ description: '위치 정보' })
 	readonly location: LocationResponseDto;
 
-	constructor({ id, name, views, location }) {
+	constructor({ id, name, views, wishes, location }) {
 		this.id = id;
 		this.name = name;
 		this.views = views;
+		this.wishes = wishes;
 		this.location = new LocationResponseDto(location);
 	}
 }

--- a/src/modules/spots/spots.controller.spec.ts
+++ b/src/modules/spots/spots.controller.spec.ts
@@ -10,11 +10,13 @@ import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
 import { Spot } from 'src/entities/spots.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { WishSpot } from 'src/entities/wish-spots.entity';
 import { MockClickSpotsRepository } from 'test/mock/click-spots.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockSnsPostsRepository } from 'test/mock/snsPosts.mock';
 import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
+import { MockWishSpotsRepository } from 'test/mock/wish-spots.mock';
 import { KakaoAuthStrategy } from '../auth/strategies/kakao-auth.strategy';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsController } from './spots.controller';
@@ -59,6 +61,10 @@ describe('SpotsController', () => {
 				{
 					provide: getRepositoryToken(ClickSpot),
 					useClass: MockClickSpotsRepository,
+				},
+				{
+					provide: getRepositoryToken(WishSpot),
+					useClass: MockWishSpotsRepository,
 				},
 				KakaoAuthStrategy,
 				{

--- a/src/modules/spots/spots.controller.spec.ts
+++ b/src/modules/spots/spots.controller.spec.ts
@@ -3,19 +3,22 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { JwtService } from '@nestjs/jwt';
+import { ClickSpot } from 'src/entities/click-spots.entity';
 import { Location } from 'src/entities/locations.entity';
 import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
 import { Spot } from 'src/entities/spots.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { MockClickSpotsRepository } from 'test/mock/click-spots.mock';
 import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockSnsPostsRepository } from 'test/mock/snsPosts.mock';
 import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
+import { KakaoAuthStrategy } from '../auth/strategies/kakao-auth.strategy';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsController } from './spots.controller';
 import { SpotsService } from './spots.service';
-import { KakaoAuthStrategy } from '../auth/strategies/kakao-auth.strategy';
 
 describe('SpotsController', () => {
 	let spotsController: SpotsController;
@@ -27,6 +30,12 @@ describe('SpotsController', () => {
 			controllers: [SpotsController],
 			providers: [
 				SpotsService,
+				{
+					provide: JwtService,
+					useValue: {
+						sign: () => '',
+					},
+				},
 				{
 					provide: getRepositoryToken(Location),
 					useClass: MockLocationsRepository,
@@ -47,12 +56,16 @@ describe('SpotsController', () => {
 					provide: getRepositoryToken(Rank),
 					useClass: MockSnsPostsRepository,
 				},
+				{
+					provide: getRepositoryToken(ClickSpot),
+					useClass: MockClickSpotsRepository,
+				},
 				KakaoAuthStrategy,
 				{
 					provide: ConfigService,
 					useValue: {
 						get: jest.fn((key: string) => {
-							if (key === 'oauthConfig') {
+							if (key === 'oauthConfig' || key === 'jwtConfig') {
 								return 1;
 							}
 							return null;

--- a/src/modules/spots/spots.controller.ts
+++ b/src/modules/spots/spots.controller.ts
@@ -8,12 +8,15 @@ import {
 	Post,
 	Query,
 	UploadedFile,
+	UseGuards,
 	UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
 import { existsSync, mkdirSync } from 'fs';
 import { diskStorage } from 'multer';
+import { AuthUser } from 'src/decorators/auth.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { DetailSpotRequestDto } from './dto/detail-spot-request.dto';
 import { SearchRequestDto } from './dto/search-request.dto';
 
@@ -80,5 +83,13 @@ export class SpotsController {
 		@Param('spotId') spotId: number,
 	) {
 		return await this.spotsService.getDetailSpot(headers.authorization, datailRequest, spotId);
+	}
+
+	@Post(':spotId/wishes/:isWish')
+	@UseGuards(JwtAuthGuard)
+	@ApiDocs.wishSpot('여행지 찜하기')
+	async wishSpot(@AuthUser() userData, @Param('spotId') spotId: number, @Param('isWish') isWish: number) {
+		const isWishBool = isWish === 1 ? true : false;
+		return await this.spotsService.wishSpot(userData.id, spotId, isWishBool);
 	}
 }

--- a/src/modules/spots/spots.controller.ts
+++ b/src/modules/spots/spots.controller.ts
@@ -1,6 +1,7 @@
 import {
 	Controller,
 	Get,
+	Headers,
 	HttpException,
 	HttpStatus,
 	Param,
@@ -73,7 +74,11 @@ export class SpotsController {
 
 	@Get(':spotId')
 	@ApiDocs.detailSpot('여행지 상세 페이지(여행지 기본 정보, 연관 sns posts')
-	async detailSpot(@Query() datailRequest: DetailSpotRequestDto, @Param('spotId') spotId: number) {
-		return await this.spotsService.getDetailSpot(datailRequest, spotId);
+	async detailSpot(
+		@Headers() headers,
+		@Query() datailRequest: DetailSpotRequestDto,
+		@Param('spotId') spotId: number,
+	) {
+		return await this.spotsService.getDetailSpot(headers.authorization, datailRequest, spotId);
 	}
 }

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { boolean } from 'joi';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
@@ -92,6 +92,28 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '',
 				type: DetailSpotResponseDto,
 			}),
+		);
+	},
+	wishSpot(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '여행지 찜하기',
+			}),
+			ApiParam({
+				name: 'spotId',
+				type: Number,
+			}),
+			ApiParam({
+				name: 'isWish',
+				type: Boolean,
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: Boolean,
+			}),
+			ApiBearerAuth('Authorization'),
 		);
 	},
 };

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -106,10 +106,10 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 			}),
 			ApiParam({
 				name: 'isWish',
-				type: Boolean,
+				type: Number,
 			}),
 			ApiResponse({
-				status: 200,
+				status: 201,
 				description: '',
 				type: Boolean,
 			}),

--- a/src/modules/spots/spots.module.ts
+++ b/src/modules/spots/spots.module.ts
@@ -1,19 +1,29 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { HttpModule } from '@nestjs/axios';
+import { JwtModule } from '@nestjs/jwt';
+import { ClickSpot } from 'src/entities/click-spots.entity';
 import { Location } from 'src/entities/locations.entity';
 import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
 import { Spot } from 'src/entities/spots.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { RanksModule } from '../ranks/ranks.module';
+import { RanksService } from '../ranks/ranks.service';
 import { SpotsController } from './spots.controller';
 import { SpotsService } from './spots.service';
-import { RanksService } from '../ranks/ranks.service';
-import { RanksModule } from '../ranks/ranks.module';
-import { HttpModule } from '@nestjs/axios';
 
 @Module({
-	imports: [HttpModule, RanksModule, TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank])],
+	imports: [
+		HttpModule,
+		RanksModule,
+		TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank, ClickSpot]),
+		JwtModule.register({
+			secret: process.env.JWT_ACCESS_TOKEN_SECRET,
+			signOptions: { expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME },
+		}),
+	],
 	controllers: [SpotsController],
 	providers: [SpotsService, RanksService],
 })

--- a/src/modules/spots/spots.module.ts
+++ b/src/modules/spots/spots.module.ts
@@ -9,6 +9,7 @@ import { Rank } from 'src/entities/rank.entity';
 import { SnsPost } from 'src/entities/sns-posts.entity';
 import { Spot } from 'src/entities/spots.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { WishSpot } from 'src/entities/wish-spots.entity';
 import { RanksModule } from '../ranks/ranks.module';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsController } from './spots.controller';
@@ -18,7 +19,7 @@ import { SpotsService } from './spots.service';
 	imports: [
 		HttpModule,
 		RanksModule,
-		TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank, ClickSpot]),
+		TypeOrmModule.forFeature([Spot, Location, Theme, SnsPost, Rank, ClickSpot, WishSpot]),
 		JwtModule.register({
 			secret: process.env.JWT_ACCESS_TOKEN_SECRET,
 			signOptions: { expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME },

--- a/src/modules/spots/spots.service.spec.ts
+++ b/src/modules/spots/spots.service.spec.ts
@@ -17,7 +17,9 @@ import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { ClickSpot } from 'src/entities/click-spots.entity';
+import { WishSpot } from 'src/entities/wish-spots.entity';
 import { MockClickSpotsRepository } from 'test/mock/click-spots.mock';
+import { MockWishSpotsRepository } from 'test/mock/wish-spots.mock';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsService } from './spots.service';
 
@@ -63,6 +65,10 @@ describe('SpotsService', () => {
 				{
 					provide: getRepositoryToken(ClickSpot),
 					useClass: MockClickSpotsRepository,
+				},
+				{
+					provide: getRepositoryToken(WishSpot),
+					useClass: MockWishSpotsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/spots/spots.service.spec.ts
+++ b/src/modules/spots/spots.service.spec.ts
@@ -13,10 +13,13 @@ import { MockSpotsRepository } from 'test/mock/spots.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
 import { DetailSpotRequestDto } from './dto/detail-spot-request.dto';
 
+import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { ClickSpot } from 'src/entities/click-spots.entity';
+import { MockClickSpotsRepository } from 'test/mock/click-spots.mock';
 import { RanksService } from '../ranks/ranks.service';
 import { SpotsService } from './spots.service';
-import { HttpService } from '@nestjs/axios';
 
 describe('SpotsService', () => {
 	let spotsService: SpotsService;
@@ -31,6 +34,12 @@ describe('SpotsService', () => {
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				SpotsService,
+				{
+					provide: JwtService,
+					useValue: {
+						sign: () => '',
+					},
+				},
 				{
 					provide: getRepositoryToken(Spot),
 					useClass: MockSpotsRepository,
@@ -52,10 +61,14 @@ describe('SpotsService', () => {
 					useClass: MockRankRepository,
 				},
 				{
+					provide: getRepositoryToken(ClickSpot),
+					useClass: MockClickSpotsRepository,
+				},
+				{
 					provide: ConfigService,
 					useValue: {
 						get: jest.fn((key: string) => {
-							if (key === 'oauthConfig') {
+							if (key === 'oauthConfig' || key === 'jwtConfig') {
 								return 1;
 							}
 							return null;

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -432,30 +432,26 @@ export class SpotsService {
 			.getOne();
 		console.log(isWish);
 		if (!IsSpot) throw new NotFoundException('Spot is not found');
-		try {
-			if (isWish) {
-				const isWishSpot = await this.wishSpotsRepository
-					.createQueryBuilder('wishSpot')
-					.where('wishSpot.userId = :userId', { userId })
-					.andWhere('wishSpot.spotId = :spotId', { spotId })
-					.getOne();
-				if (!isWishSpot) {
-					const wishSpot = this.wishSpotsRepository.create({
-						userId,
-						spotId,
-					});
-					await this.wishSpotsRepository.save(wishSpot);
-				}
-			} else {
-				await this.wishSpotsRepository.delete({
+		if (isWish) {
+			const isWishSpot = await this.wishSpotsRepository
+				.createQueryBuilder('wishSpot')
+				.where('wishSpot.userId = :userId', { userId })
+				.andWhere('wishSpot.spotId = :spotId', { spotId })
+				.getOne();
+			if (!isWishSpot) {
+				const wishSpot = this.wishSpotsRepository.create({
 					userId,
 					spotId,
 				});
-			}
-			return true;
-		} catch (error) {
-			throw new InternalServerErrorException(error.message, error);
+				await this.wishSpotsRepository.save(wishSpot);
+			} else throw new BadRequestException('User already wishes spot');
+		} else {
+			await this.wishSpotsRepository.delete({
+				userId,
+				spotId,
+			});
 		}
+		return true;
 	}
 
 	private async getNearbyFacility(latitude, longitude) {

--- a/test/mock/click-posts.mock.ts
+++ b/test/mock/click-posts.mock.ts
@@ -1,0 +1,13 @@
+export const mockClickPost = {
+	id: 1,
+	userId: 1,
+	postId: 1,
+};
+
+export class MockClickPostsRepository {
+	save = jest.fn().mockResolvedValue(mockClickPost);
+
+	async find() {
+		return mockClickPost;
+	}
+}

--- a/test/mock/click-spots.mock.ts
+++ b/test/mock/click-spots.mock.ts
@@ -1,0 +1,13 @@
+export const mockClickSpot = {
+	id: 1,
+	userId: 1,
+	spotId: 1,
+};
+
+export class MockClickSpotsRepository {
+	save = jest.fn().mockResolvedValue(mockClickSpot);
+
+	async find() {
+		return mockClickSpot;
+	}
+}

--- a/test/mock/like-posts.mock.ts
+++ b/test/mock/like-posts.mock.ts
@@ -1,0 +1,13 @@
+export const mockLikePost = {
+	id: 1,
+	userId: 1,
+	postId: 1,
+};
+
+export class MockLikePostsRepository {
+	save = jest.fn().mockResolvedValue(mockLikePost);
+
+	async find() {
+		return mockLikePost;
+	}
+}

--- a/test/mock/wish-spots.mock.ts
+++ b/test/mock/wish-spots.mock.ts
@@ -1,0 +1,13 @@
+export const mockWishSpot = {
+	id: 1,
+	userId: 1,
+	spotId: 1,
+};
+
+export class MockWishSpotsRepository {
+	save = jest.fn().mockResolvedValue(mockWishSpot);
+
+	async find() {
+		return mockWishSpot;
+	}
+}


### PR DESCRIPTION
## 개요
- 사용자 로그 수집 api를 구현했습니다.
  - 여행지, 게시글 클릭 API -> click-spot, click-post table에 기록
  - 여행지 찜하기 API
  - 게시글 좋아요 API
  - 여행지 목록 (검색, 랭킹, 추천 (map제외)) : 조회수, 찜 개수 추가
  - 여행지 상세정보 : 조회수, 찜 개수, 찜 여부 추가
  - 게시글 목록 : 조회수, 좋아요 개수, 좋아요 여부 추가
  - 게시글 상세정보 : 조회수, 좋아요 개수, 좋아요 여부 추가
## 작업사항
- click-spot entity
- click-post entity
- wish-spot entity
- like-post entity
- 위 api
- 여행지 목록 및 상세정보 api는 token을 보내도 되고 안보내도 됩니다. (보내면 회원으로 인식)
## 테스트
- 위에 명시한 api들 테스트 부탁드려요
- 목록, 상세정보 api에서 추가된 값들 잘 나오는지 확인 부탁드려요.
- 추가할 데이터 있으면 말씀해주세요