### PR TITLE
Feat: Report-post api

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { FiltersModule } from './modules/filters/filters.module';
 import { PostsModule } from './modules/posts/posts.module';
 import { RanksModule } from './modules/ranks/ranks.module';
 import { RecommendationsModule } from './modules/recommendations/recommendations.module';
+import { ReportPostsModule } from './modules/report-posts/report-posts.module';
 import { SpotsModule } from './modules/spots/spots.module';
 import { TasteThemesModule } from './modules/taste-themes/taste-themes.module';
 import { UsersModule } from './modules/users/users.module';
@@ -32,6 +33,7 @@ import { ViewController } from './views/view.controller';
 		RanksModule,
 		RecommendationsModule,
 		PostsModule,
+		ReportPostsModule,
 	],
 	controllers: [AppController, ViewController],
 	providers: [AppService],

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -7,6 +7,7 @@ import { LikePost } from './like-posts.entity';
 import { Location } from './locations.entity';
 import { PostComment } from './post-comments.entity';
 import { PostTheme } from './post-themes.entity';
+import { ReportPost } from './report-posts.entity';
 import { User } from './users.entity';
 
 @Entity()
@@ -78,4 +79,9 @@ export class Post extends CommonEntity {
 		cascade: true,
 	})
 	likePosts: LikePost[];
+
+	@OneToMany(() => ReportPost, (reportPost: ReportPost) => reportPost.post, {
+		cascade: true,
+	})
+	reportPosts: ReportPost[];
 }

--- a/src/entities/report-posts.entity.ts
+++ b/src/entities/report-posts.entity.ts
@@ -43,6 +43,6 @@ export class ReportPost extends CommonEntity {
 
 	@IsString()
 	@IsNotEmpty()
-	@Column({ type: 'enum', enum: AdFormType, length: 10, nullable: false, default: AdFormType.Todo })
+	@Column({ type: 'enum', enum: AdFormType, nullable: false, default: AdFormType.Todo })
 	status: AdFormType;
 }

--- a/src/entities/report-posts.entity.ts
+++ b/src/entities/report-posts.entity.ts
@@ -1,0 +1,48 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { AdFormType } from 'src/types/ad-form.types';
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Post } from './posts.entity';
+import { User } from './users.entity';
+
+@Entity()
+@Unique(['userId', 'postId'])
+export class ReportPost extends CommonEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'user_id' })
+	userId: number;
+
+	@ManyToOne(() => User, (user: User) => user.reportPosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+	user: User;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@Column({ name: 'post_id' })
+	postId: number;
+
+	@ManyToOne(() => Post, (post: Post) => post.reportPosts, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn([
+		{
+			name: 'post_id',
+			referencedColumnName: 'id',
+		},
+	])
+	post: Post;
+
+	@IsString()
+	@IsNotEmpty()
+	@Column({ type: 'varchar', length: 100, nullable: false })
+	reason: string;
+
+	@IsString()
+	@IsNotEmpty()
+	@Column({ type: 'enum', enum: AdFormType, length: 10, nullable: false, default: AdFormType.Todo })
+	status: AdFormType;
+}

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -8,6 +8,7 @@ import { CommonEntity } from './common.entity';
 import { LikePost } from './like-posts.entity';
 import { PostComment } from './post-comments.entity';
 import { Post } from './posts.entity';
+import { ReportPost } from './report-posts.entity';
 import { TasteTheme } from './taste-themes.entity';
 import { WishSpot } from './wish-spots.entity';
 
@@ -80,4 +81,9 @@ export class User extends CommonEntity {
 		cascade: true,
 	})
 	likePosts: LikePost[];
+
+	@OneToMany(() => ReportPost, (reportPost: ReportPost) => reportPost.user, {
+		cascade: true,
+	})
+	reportPosts: ReportPost[];
 }

--- a/src/modules/ad-forms/ad-forms.controller.ts
+++ b/src/modules/ad-forms/ad-forms.controller.ts
@@ -34,7 +34,6 @@ export class AdFormsController {
 		}),
 	)
 	async registerAdForm(@UploadedFile() licenseFile: Express.Multer.File, @Body() adFormData: AdFormsRequestDto) {
-		console.log(adFormData);
 		return await this.adformsService.registerAdForm(licenseFile, adFormData);
 	}
 }

--- a/src/modules/posts/dto/main-posts-response.dto.ts
+++ b/src/modules/posts/dto/main-posts-response.dto.ts
@@ -15,6 +15,10 @@ export class MainPostsResponseDto {
 	@ApiProperty({ description: '작성자 정보' })
 	readonly user: CommentsUserResponseDto;
 
+	@IsString()
+	@ApiProperty({ example: '서울시 중구 ~', description: '주소' })
+	readonly address: string;
+
 	@IsDateString()
 	@ApiProperty({ example: '2022-11-11', description: '게시글 작성 날짜' })
 	readonly createdAt: Date;
@@ -38,10 +42,11 @@ export class MainPostsResponseDto {
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })
 	readonly photoUrls: string[];
 
-	constructor({ id, title, user, createdAt, views, likes, isLike, location, photoUrls }) {
+	constructor({ id, title, user, address, createdAt, views, likes, isLike, location, photoUrls }) {
 		this.id = id;
 		this.title = title;
 		this.user = user;
+		this.address = address;
 		this.createdAt = createdAt;
 		this.views = views;
 		this.likes = likes;

--- a/src/modules/posts/dto/report-posts-request.dto.ts
+++ b/src/modules/posts/dto/report-posts-request.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class ReportPostsRequestDto {
+	@IsString()
+	@ApiProperty({ example: 'test', description: '신고 사유' })
+	readonly reason: string;
+}

--- a/src/modules/posts/dto/report-posts-response.dto.ts
+++ b/src/modules/posts/dto/report-posts-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class ReportPostsResponseDto {
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '커뮤니티 게시글 신고 id' })
+	readonly id: number;
+
+	constructor({ id }) {
+		this.id = id;
+	}
+}

--- a/src/modules/posts/posts.controller.spec.ts
+++ b/src/modules/posts/posts.controller.spec.ts
@@ -8,6 +8,7 @@ import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
+import { ReportPost } from 'src/entities/report-posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockAdFormsRepository } from 'test/mock/ad-forms.mock';
 import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
@@ -16,6 +17,7 @@ import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
 import { MockPostThemesRepository } from 'test/mock/postThemes.mock';
+import { MockReportPostsRepository } from 'test/mock/report-posts.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
 import { PostsController } from './posts.controller';
@@ -62,6 +64,10 @@ describe('PostsController', () => {
 				{
 					provide: getRepositoryToken(AdForm),
 					useClass: MockAdFormsRepository,
+				},
+				{
+					provide: getRepositoryToken(ReportPost),
+					useClass: MockReportPostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { MainPostsRequestDto } from './dto/main-posts-request.dto';
 import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
 import { PostsRequestDto } from './dto/posts-request.dto';
+import { ReportPostsRequestDto } from './dto/report-posts-request.dto';
 import { UpdatePostsRequestDto } from './dto/update-posts-request.dto';
 import { ApiDocs } from './posts.docs';
 import { PostsService } from './posts.service';
@@ -140,5 +141,11 @@ export class PostsController {
 	async likePost(@AuthUser() userData, @Param('postId') postId: number, @Param('isLike') isLike: number) {
 		const isLikeBool = isLike === 1 ? true : false;
 		return await this.postsService.likePost(userData.id, postId, isLikeBool);
+	}
+
+	@Post(':postId/reports')
+	@ApiDocs.reportPost('커뮤니티 게시글 신고하기')
+	async reportPost(@AuthUser() userData, @Param('postId') postId: number, @Body() reportData: ReportPostsRequestDto) {
+		return await this.postsService.reportPost(userData.id, postId, reportData);
 	}
 }

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -109,7 +109,7 @@ export class PostsController {
 	@Delete(':postId')
 	@ApiDocs.deletePost('커뮤니티 게시글 삭제')
 	async deletePost(@AuthUser() userData, @Param('postId') postId: number) {
-		return await this.postsService.deletePost(userData.id, postId);
+		return await this.postsService.deletePost(userData.id, userData.role, postId);
 	}
 
 	@Post(':postId/comments')

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -3,6 +3,7 @@ import {
 	Controller,
 	Delete,
 	Get,
+	HttpCode,
 	HttpException,
 	HttpStatus,
 	Param,
@@ -104,6 +105,7 @@ export class PostsController {
 		return await this.postsService.getPost(userData.id, postId);
 	}
 
+	@HttpCode(204)
 	@Delete(':postId')
 	@ApiDocs.deletePost('커뮤니티 게시글 삭제')
 	async deletePost(@AuthUser() userData, @Param('postId') postId: number) {
@@ -126,6 +128,7 @@ export class PostsController {
 		return await this.postsService.getPostsComments(userData.id, postId);
 	}
 
+	@HttpCode(204)
 	@Delete(':postId/comments/:commentId')
 	@ApiDocs.deletePostsComment('커뮤니티 게시글 댓글 삭제')
 	async deletePostsComment(

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -136,7 +136,6 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 			ApiResponse({
 				status: 204,
 				description: '삭제 완료',
-				type: Boolean,
 			}),
 			ApiBearerAuth('Authorization'),
 		);
@@ -197,7 +196,6 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 			ApiResponse({
 				status: 204,
 				description: '삭제 완료',
-				type: Boolean,
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -8,6 +8,8 @@ import { MainPostsPageResponseDto } from './dto/main-posts-page-response.dto';
 import { PostCommentsRequestDto } from './dto/post-comments-request.dto';
 import { PostCommentsResponseDto } from './dto/post-comments-response.dto';
 import { PostsResponseDto } from './dto/posts-response.dto';
+import { ReportPostsRequestDto } from './dto/report-posts-request.dto';
+import { ReportPostsResponseDto } from './dto/report-posts-response.dto';
 import { PostsController } from './posts.controller';
 
 export const ApiDocs: SwaggerMethodDoc<PostsController> = {
@@ -262,6 +264,27 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 				status: 200,
 				description: '',
 				type: MainPostsPageResponseDto,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	reportPost(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '커뮤니티 게시글 신고하기',
+			}),
+			ApiParam({
+				name: 'postId',
+				type: Number,
+			}),
+			ApiBody({
+				type: ReportPostsRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: ReportPostsResponseDto,
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -7,6 +7,7 @@ import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
+import { ReportPost } from 'src/entities/report-posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { AdFormsModule } from '../ad-forms/ad-forms.module';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
@@ -16,7 +17,17 @@ import { PostsService } from './posts.service';
 @Module({
 	imports: [
 		AdFormsModule,
-		TypeOrmModule.forFeature([Location, Post, Theme, PostTheme, PostComment, ClickPost, LikePost, AdForm]),
+		TypeOrmModule.forFeature([
+			Location,
+			Post,
+			Theme,
+			PostTheme,
+			PostComment,
+			ClickPost,
+			LikePost,
+			AdForm,
+			ReportPost,
+		]),
 	],
 	controllers: [PostsController],
 	providers: [AdFormsService, PostsService],

--- a/src/modules/posts/posts.service.spec.ts
+++ b/src/modules/posts/posts.service.spec.ts
@@ -8,6 +8,7 @@ import { Location } from 'src/entities/locations.entity';
 import { PostComment } from 'src/entities/post-comments.entity';
 import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
+import { ReportPost } from 'src/entities/report-posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { MockAdFormsRepository } from 'test/mock/ad-forms.mock';
 import { MockClickPostsRepository } from 'test/mock/click-posts.mock';
@@ -16,6 +17,7 @@ import { MockLocationsRepository } from 'test/mock/locations.mock';
 import { MockPostCommentsRepository } from 'test/mock/post-comments.mock';
 import { MockPostsRepository } from 'test/mock/posts.mock';
 import { MockPostThemesRepository } from 'test/mock/postThemes.mock';
+import { MockReportPostsRepository } from 'test/mock/report-posts.mock';
 import { MockThemeRepository } from 'test/mock/theme.mock';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
 import { PostsService } from './posts.service';
@@ -59,6 +61,10 @@ describe('PostsService', () => {
 				{
 					provide: getRepositoryToken(AdForm),
 					useClass: MockAdFormsRepository,
+				},
+				{
+					provide: getRepositoryToken(ReportPost),
+					useClass: MockReportPostsRepository,
 				},
 				{
 					provide: ConfigService,

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -118,11 +118,7 @@ export class PostsService {
 		postData?: UpdatePostsRequestDto,
 	): Promise<PostsResponseDto> {
 		const foundUsersPost = await this.getUsersPost(userId, postId);
-
-		if (photos && photos.length === 0) {
-			throw new BadRequestException('File is not exist');
-		}
-		if (photos.length > 5) {
+		if (photos && photos.length > 5) {
 			throw new BadRequestException('Files length exeeds 5');
 		}
 		if (postData.themes && this.isDuplicateArr(postData.themes)) {
@@ -364,6 +360,7 @@ export class PostsService {
 	}
 
 	private async deleteFilesToS3(folder: string, fileUrls: Array<string>): Promise<boolean> {
+		if (fileUrls.length === 0) return true;
 		const s3 = new AWS.S3({
 			endpoint: new AWS.Endpoint(this.#ncloudConfig.storageEndPoint),
 			region: 'kr-standard',
@@ -399,7 +396,7 @@ export class PostsService {
 			.createQueryBuilder('post')
 			.leftJoinAndSelect('post.user', 'user')
 			.leftJoinAndSelect('post.location', 'location')
-			.where('user.id = :user', { userId })
+			.where('user.id = :userId', { userId })
 			.andWhere('post.id = :postId', { postId })
 			.getOne();
 	}

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -14,6 +14,7 @@ import { PostTheme } from 'src/entities/post-themes.entity';
 import { Post } from 'src/entities/posts.entity';
 import { ReportPost } from 'src/entities/report-posts.entity';
 import { Theme } from 'src/entities/theme.entity';
+import { UserType } from 'src/types/users.types';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
 import { LocationResponseDto } from '../filters/dto/location-response.dto';
 import { CommentsUserResponseDto } from '../users/dto/comments-user-response.dto';
@@ -211,10 +212,10 @@ export class PostsService {
 		}
 	}
 
-	async deletePost(userId: number, postId: number): Promise<boolean> {
+	async deletePost(userId: number, role: UserType, postId: number): Promise<boolean> {
 		const foundUsersPost = await this.getUsersPost(userId, postId);
 
-		if (!foundUsersPost) {
+		if (!foundUsersPost && role !== UserType.Admin) {
 			throw new NotFoundException('Post is not found');
 		}
 

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -311,6 +311,9 @@ export class PostsService {
 		if (!foundPost) {
 			throw new NotFoundException('Post is not found');
 		}
+		if (foundPost.user.id === userId) {
+			throw new BadRequestException('User is writer');
+		}
 		if (await this.getUsersReportPost(userId, postId)) {
 			throw new BadRequestException('User already reports post');
 		}

--- a/src/modules/report-posts/dto/all-reports-request.dto.ts
+++ b/src/modules/report-posts/dto/all-reports-request.dto.ts
@@ -1,4 +1,12 @@
-import { PartialType } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional } from 'class-validator';
 import { UpdateReportsRequestDto } from './update-reports-request.dto';
 
-export class AllReportsRequestDto extends PartialType(UpdateReportsRequestDto) {}
+export class AllReportsRequestDto extends PartialType(UpdateReportsRequestDto) {
+	@IsNumber()
+	@Type(() => Number)
+	@IsOptional()
+	@ApiProperty({ example: 1, description: '커뮤니티 게시글 id' })
+	readonly postId?: number;
+}

--- a/src/modules/report-posts/dto/all-reports-request.dto.ts
+++ b/src/modules/report-posts/dto/all-reports-request.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { UpdateReportsRequestDto } from './update-reports-request.dto';
+
+export class AllReportsRequestDto extends PartialType(UpdateReportsRequestDto) {}

--- a/src/modules/report-posts/dto/reports-response.dto.ts
+++ b/src/modules/report-posts/dto/reports-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsString } from 'class-validator';
+import { PostsResponseDto } from 'src/modules/posts/dto/posts-response.dto';
+import { UserResponseDto } from 'src/modules/users/dto/user-response.dto';
+import { AdFormType } from 'src/types/ad-form.types';
+
+export class ReportsResponseDto {
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '신고 id' })
+	readonly id: number;
+
+	@IsString()
+	@ApiProperty({ example: 'test', description: '신고 사유' })
+	readonly reason: string;
+
+	@IsEnum(AdFormType)
+	@ApiProperty({
+		enum: AdFormType,
+		example: AdFormType.Approve,
+		description: '신고 상태 기준 (신청: Todo, 승인: Approve, 거부: Reject)',
+	})
+	readonly status: AdFormType;
+
+	@ApiProperty({ description: '신고한 사용자' })
+	readonly user: UserResponseDto;
+
+	@ApiProperty({ description: '신고한 게시글 id (바로가기 -> GET posts/:id 요청)' })
+	readonly post: PostsResponseDto;
+
+	constructor({ id, reason, status, user, post }) {
+		this.id = id;
+		this.reason = reason;
+		this.status = status;
+		this.user = user;
+		this.post = post;
+	}
+}

--- a/src/modules/report-posts/dto/update-multi-reports-request.dto.ts
+++ b/src/modules/report-posts/dto/update-multi-reports-request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsEnum } from 'class-validator';
+import { AdFormType } from 'src/types/ad-form.types';
+
+export class UpdateMultiReportsRequestDto {
+	@IsArray()
+	@ArrayMinSize(1)
+	@Type(() => Number)
+	@ApiProperty({ example: [1, 2], description: '신고 id 배열' })
+	readonly reportIds: number[];
+
+	@IsEnum(AdFormType)
+	@ApiProperty({
+		enum: AdFormType,
+		example: AdFormType.Approve,
+		description: '신고 상태 기준 (신청: Todo, 승인: Approve, 거부: Reject)',
+	})
+	readonly status: AdFormType;
+}

--- a/src/modules/report-posts/dto/update-reports-request.dto.ts
+++ b/src/modules/report-posts/dto/update-reports-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { AdFormType } from 'src/types/ad-form.types';
+
+export class UpdateReportsRequestDto {
+	@IsEnum(AdFormType)
+	@ApiProperty({
+		enum: AdFormType,
+		example: AdFormType.Approve,
+		description: '신고 상태 기준 (신청: Todo, 승인: Approve, 거부: Reject)',
+	})
+	readonly status: AdFormType;
+}

--- a/src/modules/report-posts/report-posts.controller.spec.ts
+++ b/src/modules/report-posts/report-posts.controller.spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ReportPost } from 'src/entities/report-posts.entity';
+import { MockReportPostsRepository } from 'test/mock/report-posts.mock';
+import { ReportPostsController } from './report-posts.controller';
+import { ReportPostsService } from './report-posts.service';
+
+describe('ReportPostsController', () => {
+	let controller: ReportPostsController;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ReportPostsController],
+			providers: [
+				ReportPostsService,
+				{
+					provide: getRepositoryToken(ReportPost),
+					useClass: MockReportPostsRepository,
+				},
+			],
+		}).compile();
+
+		controller = module.get<ReportPostsController>(ReportPostsController);
+	});
+
+	it('should be defined', () => {
+		expect(controller).toBeDefined();
+	});
+});

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -11,18 +11,20 @@ import { ReportPostsService } from './report-posts.service';
 @Controller('report-posts')
 @ApiTags('report-posts - 신고글 정보')
 @UseGuards(JwtAuthGuard)
-@UseGuards(RolesGuard)
-@Roles(UserType.Admin)
 export class ReportPostsController {
 	constructor(private readonly reportPostsService: ReportPostsService) {}
 
 	@Get()
+	@UseGuards(RolesGuard)
+	@Roles(UserType.Admin)
 	@ApiDocs.getAllReports('신고 목록 반환')
 	async getAllReports() {
 		return await this.reportPostsService.getAllReports();
 	}
 
 	@Patch(':reportId')
+	@UseGuards(RolesGuard)
+	@Roles(UserType.Admin)
 	@ApiDocs.updateReportsStatus('신고 상태 수정하기')
 	async updateReportsStatus(@Param('reportId') reportId: number, @Body() updateReportData: UpdateReportsRequestDto) {
 		return await this.reportPostsService.updateReportsStatus(reportId, updateReportData);
@@ -30,6 +32,8 @@ export class ReportPostsController {
 
 	@HttpCode(204)
 	@Delete(':reportId')
+	@UseGuards(RolesGuard)
+	@Roles(UserType.Admin)
 	@ApiDocs.deleteReports('신고 삭제하기')
 	async deleteReports(@Param('reportId') reportId: number) {
 		return await this.reportPostsService.deleteReports(reportId);

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -27,7 +27,7 @@ export class ReportPostsController {
 	@Patch()
 	@UseGuards(RolesGuard)
 	@Roles(UserType.Admin)
-	@ApiDocs.updateMultiReportsStatus('어러 신고 상태 수정하기')
+	@ApiDocs.updateMultiReportsStatus('여러 신고 상태 수정하기')
 	async updateMultiReportsStatus(@Body() reportIdsData: UpdateMultiReportsRequestDto) {
 		return await this.reportPostsService.updateMultiReportsStatus(reportIdsData);
 	}

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Patch, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, HttpCode, Param, Patch, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Roles } from 'src/decorators/roles.decorator';
 import { UserType } from 'src/types/users.types';
@@ -20,5 +20,12 @@ export class ReportPostsController {
 	@ApiDocs.updateReportsStatus('신고 상태 수정하기')
 	async updateReportsStatus(@Param('reportId') reportId: number, @Body() updateReportData: UpdateReportsRequestDto) {
 		return await this.reportPostsService.updateReportsStatus(reportId, updateReportData);
+	}
+
+	@HttpCode(204)
+	@Delete(':reportId')
+	@ApiDocs.deleteReports('신고 삭제하기')
+	async deleteReports(@Param('reportId') reportId: number) {
+		return await this.reportPostsService.deleteReports(reportId);
 	}
 }

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -5,6 +5,7 @@ import { UserType } from 'src/types/users.types';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/role.guard';
 import { AllReportsRequestDto } from './dto/all-reports-request.dto';
+import { UpdateMultiReportsRequestDto } from './dto/update-multi-reports-request.dto';
 import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
 import { ApiDocs } from './report-posts.docs';
 import { ReportPostsService } from './report-posts.service';
@@ -21,6 +22,14 @@ export class ReportPostsController {
 	@ApiDocs.getAllReports('신고 목록 반환')
 	async getAllReports(@Query() filter?: AllReportsRequestDto) {
 		return await this.reportPostsService.getAllReports(filter);
+	}
+
+	@Patch()
+	@UseGuards(RolesGuard)
+	@Roles(UserType.Admin)
+	@ApiDocs.updateMultiReportsStatus('어러 신고 상태 수정하기')
+	async updateMultiReportsStatus(@Body() reportIdsData: UpdateMultiReportsRequestDto) {
+		return await this.reportPostsService.updateMultiReportsStatus(reportIdsData);
 	}
 
 	@Patch(':reportId')

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Roles } from 'src/decorators/roles.decorator';
 import { UserType } from 'src/types/users.types';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/role.guard';
+import { AllReportsRequestDto } from './dto/all-reports-request.dto';
 import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
 import { ApiDocs } from './report-posts.docs';
 import { ReportPostsService } from './report-posts.service';
@@ -18,8 +19,8 @@ export class ReportPostsController {
 	@UseGuards(RolesGuard)
 	@Roles(UserType.Admin)
 	@ApiDocs.getAllReports('신고 목록 반환')
-	async getAllReports() {
-		return await this.reportPostsService.getAllReports();
+	async getAllReports(@Query() filter?: AllReportsRequestDto) {
+		return await this.reportPostsService.getAllReports(filter);
 	}
 
 	@Patch(':reportId')

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, HttpCode, Param, Patch, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Roles } from 'src/decorators/roles.decorator';
 import { UserType } from 'src/types/users.types';
@@ -15,6 +15,12 @@ import { ReportPostsService } from './report-posts.service';
 @Roles(UserType.Admin)
 export class ReportPostsController {
 	constructor(private readonly reportPostsService: ReportPostsService) {}
+
+	@Get()
+	@ApiDocs.getAllReports('신고 목록 반환')
+	async getAllReports() {
+		return await this.reportPostsService.getAllReports();
+	}
 
 	@Patch(':reportId')
 	@ApiDocs.updateReportsStatus('신고 상태 수정하기')

--- a/src/modules/report-posts/report-posts.controller.ts
+++ b/src/modules/report-posts/report-posts.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Param, Patch, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Roles } from 'src/decorators/roles.decorator';
+import { UserType } from 'src/types/users.types';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/role.guard';
+import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
+import { ApiDocs } from './report-posts.docs';
+import { ReportPostsService } from './report-posts.service';
+
+@Controller('report-posts')
+@ApiTags('report-posts - 신고글 정보')
+@UseGuards(JwtAuthGuard)
+@UseGuards(RolesGuard)
+@Roles(UserType.Admin)
+export class ReportPostsController {
+	constructor(private readonly reportPostsService: ReportPostsService) {}
+
+	@Patch(':reportId')
+	@ApiDocs.updateReportsStatus('신고 상태 수정하기')
+	async updateReportsStatus(@Param('reportId') reportId: number, @Body() updateReportData: UpdateReportsRequestDto) {
+		return await this.reportPostsService.updateReportsStatus(reportId, updateReportData);
+	}
+}

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { ReportsResponseDto } from './dto/reports-response.dto';
@@ -12,6 +12,16 @@ export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
 			ApiOperation({
 				summary,
 				description: '신고 목록 반환',
+			}),
+			ApiQuery({
+				name: 'status',
+				required: false,
+				description: '신고 상태',
+			}),
+			ApiQuery({
+				name: 'postId',
+				required: false,
+				description: '커뮤니티 게시글 id',
 			}),
 			ApiResponse({
 				status: 200,

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -27,4 +27,21 @@ export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	deleteReports(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '신고 삭제하기',
+			}),
+			ApiParam({
+				name: 'reportId',
+				type: Number,
+			}),
+			ApiResponse({
+				status: 204,
+				description: '',
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 };

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -31,6 +31,28 @@ export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	updateMultiReportsStatus(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '여러 신고 상태 수정하기',
+			}),
+			ApiQuery({
+				name: 'reportIds',
+				required: true,
+				description: '신고 id 배열 (reportIds=1,2,3)',
+			}),
+			ApiBody({
+				type: UpdateReportsRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 	updateReportsStatus(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
+import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
+import { ReportPostsController } from './report-posts.controller';
+
+export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
+	updateReportsStatus(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '신고 상태 수정하기',
+			}),
+			ApiParam({
+				name: 'reportId',
+				type: Number,
+			}),
+			ApiBody({
+				type: UpdateReportsRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+};

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse }
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { ReportsResponseDto } from './dto/reports-response.dto';
+import { UpdateMultiReportsRequestDto } from './dto/update-multi-reports-request.dto';
 import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
 import { ReportPostsController } from './report-posts.controller';
 
@@ -37,13 +38,8 @@ export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
 				summary,
 				description: '여러 신고 상태 수정하기',
 			}),
-			ApiQuery({
-				name: 'reportIds',
-				required: true,
-				description: '신고 id 배열 (reportIds=1,2,3)',
-			}),
 			ApiBody({
-				type: UpdateReportsRequestDto,
+				type: UpdateMultiReportsRequestDto,
 			}),
 			ApiResponse({
 				status: 201,

--- a/src/modules/report-posts/report-posts.docs.ts
+++ b/src/modules/report-posts/report-posts.docs.ts
@@ -2,10 +2,25 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
+import { ReportsResponseDto } from './dto/reports-response.dto';
 import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
 import { ReportPostsController } from './report-posts.controller';
 
 export const ApiDocs: SwaggerMethodDoc<ReportPostsController> = {
+	getAllReports(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '신고 목록 반환',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: [ReportsResponseDto],
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 	updateReportsStatus(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/src/modules/report-posts/report-posts.module.ts
+++ b/src/modules/report-posts/report-posts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReportPost } from 'src/entities/report-posts.entity';
+import { ReportPostsController } from './report-posts.controller';
+import { ReportPostsService } from './report-posts.service';
+
+@Module({
+	imports: [TypeOrmModule.forFeature([ReportPost])],
+	controllers: [ReportPostsController],
+	providers: [ReportPostsService],
+})
+export class ReportPostsModule {}

--- a/src/modules/report-posts/report-posts.service.spec.ts
+++ b/src/modules/report-posts/report-posts.service.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ReportPost } from 'src/entities/report-posts.entity';
+import { MockReportPostsRepository } from 'test/mock/report-posts.mock';
+import { ReportPostsService } from './report-posts.service';
+
+describe('ReportPostsService', () => {
+	let service: ReportPostsService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				ReportPostsService,
+				{
+					provide: getRepositoryToken(ReportPost),
+					useClass: MockReportPostsRepository,
+				},
+			],
+		}).compile();
+
+		service = module.get<ReportPostsService>(ReportPostsService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/src/modules/report-posts/report-posts.service.ts
+++ b/src/modules/report-posts/report-posts.service.ts
@@ -20,6 +20,15 @@ export class ReportPostsService {
 		return true;
 	}
 
+	async deleteReports(reportId: number): Promise<boolean> {
+		const foundReport = await this.foundReportData(reportId);
+		if (!foundReport) {
+			throw new NotFoundException('Report is not found');
+		}
+		await this.reportPostsRepository.delete(reportId);
+		return true;
+	}
+
 	private async foundReportData(reportId: number) {
 		return await this.reportPostsRepository
 			.createQueryBuilder('reportPost')

--- a/src/modules/report-posts/report-posts.service.ts
+++ b/src/modules/report-posts/report-posts.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ReportPost } from 'src/entities/report-posts.entity';
+import { Repository } from 'typeorm';
+import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
+
+@Injectable()
+export class ReportPostsService {
+	constructor(
+		@InjectRepository(ReportPost)
+		private readonly reportPostsRepository: Repository<ReportPost>,
+	) {}
+
+	async updateReportsStatus(reportId: number, updateReportData: UpdateReportsRequestDto): Promise<boolean> {
+		const foundReport = await this.foundReportData(reportId);
+		if (!foundReport) {
+			throw new NotFoundException('Report is not found');
+		}
+		await this.reportPostsRepository.update(reportId, updateReportData);
+		return true;
+	}
+
+	private async foundReportData(reportId: number) {
+		return await this.reportPostsRepository
+			.createQueryBuilder('reportPost')
+			.leftJoinAndSelect('reportPost.user', 'user')
+			.leftJoinAndSelect('reportPost.post', 'post')
+			.where('reportPost.id = :reportId', { reportId })
+			.getOne();
+	}
+}

--- a/src/modules/report-posts/report-posts.service.ts
+++ b/src/modules/report-posts/report-posts.service.ts
@@ -2,6 +2,9 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ReportPost } from 'src/entities/report-posts.entity';
 import { Repository } from 'typeorm';
+import { PostsResponseDto } from '../posts/dto/posts-response.dto';
+import { UserResponseDto } from '../users/dto/user-response.dto';
+import { ReportsResponseDto } from './dto/reports-response.dto';
 import { UpdateReportsRequestDto } from './dto/update-reports-request.dto';
 
 @Injectable()
@@ -10,6 +13,19 @@ export class ReportPostsService {
 		@InjectRepository(ReportPost)
 		private readonly reportPostsRepository: Repository<ReportPost>,
 	) {}
+
+	async getAllReports(): Promise<ReportsResponseDto[]> {
+		const foundAllReports = await this.foundAllReportDatas();
+		console.log(foundAllReports);
+		return foundAllReports.map(
+			(report) =>
+				new ReportsResponseDto({
+					...report,
+					user: new UserResponseDto(report.user),
+					post: new PostsResponseDto(report.post),
+				}),
+		);
+	}
 
 	async updateReportsStatus(reportId: number, updateReportData: UpdateReportsRequestDto): Promise<boolean> {
 		const foundReport = await this.foundReportData(reportId);
@@ -36,5 +52,14 @@ export class ReportPostsService {
 			.leftJoinAndSelect('reportPost.post', 'post')
 			.where('reportPost.id = :reportId', { reportId })
 			.getOne();
+	}
+
+	private async foundAllReportDatas() {
+		return await this.reportPostsRepository
+			.createQueryBuilder('reportPost')
+			.leftJoinAndSelect('reportPost.user', 'user')
+			.leftJoinAndSelect('reportPost.post', 'post')
+			.orderBy('reportPost.created_at', 'DESC')
+			.getMany();
 	}
 }

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -385,7 +385,6 @@ export class SpotsService {
 			.createQueryBuilder('spot')
 			.where('spot.id = :spotId', { spotId })
 			.getOne();
-		console.log(isWish);
 		if (!IsSpot) throw new NotFoundException('Spot is not found');
 		if (isWish) {
 			const isWishSpot = await this.wishSpotsRepository

--- a/test/mock/report-posts.mock.ts
+++ b/test/mock/report-posts.mock.ts
@@ -1,0 +1,17 @@
+import { AdFormType } from 'src/types/ad-form.types';
+
+export const mockReportPost = {
+	id: 1,
+	userId: 1,
+	postId: 1,
+	reason: 'test',
+	status: AdFormType.Todo,
+};
+
+export class MockReportPostsRepository {
+	save = jest.fn().mockResolvedValue(mockReportPost);
+
+	async find() {
+		return mockReportPost;
+	}
+}


### PR DESCRIPTION
## 개요
- 게시글 신고 관련 api를 구현했습니다.
  - 게시글 신고하기 api (모든 유저)
  - 신고목록 상태 필터링 정렬 api (default=최신순 정렬) (관리자)
  - 신고 상태 수정하기 api (관리자)
  - 신고 삭제 api (관리자)
  - 관리자가 게시글 삭제 api (관리자)
## 작업사항
- report-post entity 생성
- POST posts/:id/reports : 게시글 신고
- GET report-posts(?status=) : 신고목록 상태 필터링 정렬 (status 쿼리 안보내면 최신순 정렬)
- PATCH report-posts/:id : 신고 상태 수정
- DELETE report-posts/:id : 신고 삭제
- DELETE posts/:id : (기존에 있던 api), 게시글 작성자 뿐만 아니라 관리자도 스스로 판단 하에 삭제가 가능하도록 수정
- ## 테스트
- 위에 명시한 api들 모두 테스트 부탁드려요 (관리자, 일반회원 각각 테스트 부탁드려용 잘 막히는지 등등 ㅎㅎ)