### PR TITLE
Feat: Update facebook login login & Add logout, resign api

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
             dockerfile: ./Dockerfile.dev
         container_name: capstone-server
         ports:
-            - '3000:3000'
+            - '80:3000'
         volumes:
             - ./:/app
         restart: always

--- a/src/entities/ad-form.entity.ts
+++ b/src/entities/ad-form.entity.ts
@@ -1,9 +1,8 @@
-import { IsEmail, IsNotEmpty, IsNumber, IsString } from 'class-validator';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { Column, Entity } from 'typeorm';
 
 import { AdFormType } from 'src/types/ad-form.types';
 import { CommonEntity } from './common.entity';
-import { Location } from './locations.entity';
 
 @Entity()
 export class AdForm extends CommonEntity {
@@ -15,18 +14,6 @@ export class AdForm extends CommonEntity {
 	@IsString()
 	@Column({ type: 'varchar', length: 100, nullable: false })
 	address: string;
-
-	@IsNumber()
-	@IsNotEmpty()
-	@Column({ name: 'location_id', nullable: true })
-	locationId: number;
-
-	@ManyToOne(() => Location, (location: Location) => location.adForms, {
-		onDelete: 'SET NULL',
-		nullable: true,
-	})
-	@JoinColumn([{ name: 'location_id', referencedColumnName: 'id' }])
-	location: Location;
 
 	@IsEmail()
 	@IsNotEmpty()

--- a/src/entities/locations.entity.ts
+++ b/src/entities/locations.entity.ts
@@ -1,6 +1,5 @@
 import { IsString } from 'class-validator';
 import { Column, Entity, Index, OneToMany } from 'typeorm';
-import { AdForm } from './ad-form.entity';
 
 import { CommonEntity } from './common.entity';
 import { Post } from './posts.entity';
@@ -28,10 +27,4 @@ export class Location extends CommonEntity {
 		eager: true,
 	})
 	posts: Post[];
-
-	@OneToMany(() => AdForm, (adForm: AdForm) => adForm.location, {
-		cascade: true,
-		eager: true,
-	})
-	adForms: AdForm[];
 }

--- a/src/modules/ad-forms/ad-forms.service.ts
+++ b/src/modules/ad-forms/ad-forms.service.ts
@@ -27,12 +27,6 @@ export class AdFormsService {
 			throw new BadRequestException('File is not exist');
 		}
 
-		const metroLocalName = this.getMetroLocalName(adFormData.address);
-		const locationId = await this.getAddressLocationId(
-			metroLocalName.isOneLevel,
-			metroLocalName.metroName,
-			metroLocalName.localName,
-		);
 		const licenseUrl = await this.uploadFileToS3('licenses', licenseFile);
 		try {
 			await this.adFormsRepository.save({
@@ -41,7 +35,6 @@ export class AdFormsService {
 				email: adFormData.email ? adFormData.email : null,
 				requirement: adFormData.requirement,
 				licenseUrl,
-				locationId,
 			});
 
 			return true;

--- a/src/modules/admins/admins.service.ts
+++ b/src/modules/admins/admins.service.ts
@@ -1,26 +1,26 @@
 import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
-import { In, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as AWS from 'aws-sdk';
+import { In, Repository } from 'typeorm';
 import { uuid } from 'uuidv4';
 
-import { Ad } from 'src/entities/ad.entity';
-import { AdForm } from 'src/entities/ad-form.entity';
-import { Location } from 'src/entities/locations.entity';
 import { NcloudConfig } from 'src/config/config.constant';
+import { AdForm } from 'src/entities/ad-form.entity';
+import { Ad } from 'src/entities/ad.entity';
+import { Location } from 'src/entities/locations.entity';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
-import { AdsResponseDto } from './dto/ads-response.dto';
-import { GetAdResponseDto } from './dto/get-ad-response.dto';
+import { LocationResponseDto } from '../filters/dto/location-response.dto';
+import { AdFormsFilterRequestDto } from './dto/ad-forms-filter-request.dto';
+import { AdFormsResponseDto } from './dto/ad-forms-response.dto';
+import { AdFormsStatusRequestDto } from './dto/ad-forms-status-request.dto';
 import { AdsRegisterRequestDto } from './dto/ads-register-request.dto';
+import { AdsResponseDto } from './dto/ads-response.dto';
 import { GetAdFilterRequestDto } from './dto/get-ad-filter-request.dto';
 import { GetAdFilterResponseDto } from './dto/get-ad-filter-response.dto';
-import { AdFormsResponseDto } from './dto/ad-forms-response.dto';
-import { UpdateAdsRequestDto } from './dto/update-ads-request.dto';
 import { GetAdFormResponseDto } from './dto/get-ad-form.response.dto';
-import { AdFormsStatusRequestDto } from './dto/ad-forms-status-request.dto';
-import { AdFormsFilterRequestDto } from './dto/ad-forms-filter-request.dto';
-import { LocationResponseDto } from '../filters/dto/location-response.dto';
+import { GetAdResponseDto } from './dto/get-ad-response.dto';
+import { UpdateAdsRequestDto } from './dto/update-ads-request.dto';
 
 @Injectable()
 export class AdminsService {
@@ -52,10 +52,7 @@ export class AdminsService {
 		const adForm = await this.adFormsRepository.findOne({ where: { id: adFormId } });
 		if (!adForm) throw new NotFoundException('AdForm is not found');
 		try {
-			const locationDto = new LocationResponseDto(
-				await this.locationsRepository.findOne({ where: { id: adForm.locationId } }),
-			);
-			return new GetAdFormResponseDto({ ...adForm, location: locationDto });
+			return new GetAdFormResponseDto(adForm);
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);
 		}

--- a/src/modules/admins/dto/get-ad-form.response.dto.ts
+++ b/src/modules/admins/dto/get-ad-form.response.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDateString, IsEmail, IsEnum, IsNumber, IsString } from 'class-validator';
 
-import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
 import { AdFormType } from 'src/types/ad-form.types';
 
 export class GetAdFormResponseDto {
@@ -33,9 +32,6 @@ export class GetAdFormResponseDto {
 	@ApiProperty({ example: '~해주세요', description: '요구사항' })
 	readonly requirement: string;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
-
 	@IsEnum(AdFormType)
 	@ApiProperty({
 		enum: AdFormType,
@@ -47,18 +43,7 @@ export class GetAdFormResponseDto {
 	@ApiProperty({ example: '2022-11-11', description: '광고 요청 날짜' })
 	readonly createdAt: Date;
 
-	constructor({
-		id,
-		businessName,
-		address,
-		email,
-		phoneNumber,
-		licenseUrl,
-		requirement,
-		location,
-		status,
-		createdAt,
-	}) {
+	constructor({ id, businessName, address, email, phoneNumber, licenseUrl, requirement, status, createdAt }) {
 		this.id = id;
 		this.businessName = businessName;
 		this.address = address;
@@ -66,7 +51,6 @@ export class GetAdFormResponseDto {
 		this.phoneNumber = phoneNumber;
 		this.licenseUrl = licenseUrl;
 		this.requirement = requirement;
-		this.location = location;
 		this.status = status;
 		this.createdAt = createdAt;
 	}

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -12,6 +12,7 @@ import { MockUsersRepository } from '../../../test/mock/users.mock';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { HashPassword } from './hash-password';
+import { FacebookAuthStrategy } from './strategies/facebook-auth.strategy';
 import { KakaoAuthStrategy } from './strategies/kakao-auth.strategy';
 
 describe('AuthController', () => {
@@ -33,6 +34,7 @@ describe('AuthController', () => {
 					},
 				},
 				KakaoAuthStrategy,
+				FacebookAuthStrategy,
 				{
 					provide: getRepositoryToken(User),
 					useClass: MockUsersRepository,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,10 +7,12 @@ import { AuthCodeRequestDto } from '../auth-codes/dto/auth-code-request.dto';
 import { UserResponseDto } from '../users/dto/user-response.dto';
 import { ApiDocs } from './auth.docs';
 import { AuthService } from './auth.service';
+import { DeleteUserRequestDto } from './dto/delete-user-request.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { OauthUserDto } from './dto/oauth-user.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
 import { FacebookAuthGuard } from './guards/facebook-auth.guard';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { JwtRefreshGuard } from './guards/jwt-refresh-auth.guard';
 import { KakaoAuthGuard } from './guards/kakao-auth.guard';
 import { LocalAuthGuard } from './guards/local-auth.guard';
@@ -107,5 +109,19 @@ export class AuthController {
 	@ApiDocs.generateTempPw('임시 비밀번호 메일로 발송')
 	async generateTempPw(@Body() authCodeReq: AuthCodeRequestDto) {
 		return await this.authService.generateTempPw(authCodeReq.email);
+	}
+
+	@Post('logout')
+	@UseGuards(JwtAuthGuard)
+	@ApiDocs.logout('로그아웃')
+	async logout(@AuthUser() userData) {
+		return true;
+	}
+
+	@Post('resign')
+	@UseGuards(JwtAuthGuard)
+	@ApiDocs.deleteUser('회원탈퇴')
+	async deleteUser(@AuthUser() userData, @Body() passwordReq: DeleteUserRequestDto) {
+		return await this.authService.deleteUser(userData.id, passwordReq);
 	}
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Get, Header, HttpCode, Post, Query, Redirect, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 
 import { AuthUser, FacebookUser } from 'src/decorators/auth.decorator';
@@ -11,6 +10,7 @@ import { AuthService } from './auth.service';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { OauthUserDto } from './dto/oauth-user.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
+import { FacebookAuthGuard } from './guards/facebook-auth.guard';
 import { JwtRefreshGuard } from './guards/jwt-refresh-auth.guard';
 import { KakaoAuthGuard } from './guards/kakao-auth.guard';
 import { LocalAuthGuard } from './guards/local-auth.guard';
@@ -49,16 +49,32 @@ export class AuthController {
 
 	//Test - facebook
 	@Get('/facebook-login')
-	@UseGuards(AuthGuard('facebook'))
+	@Header('Content-Type', 'text/html')
+	@Redirect()
 	@ApiDocs.getFacebookLoginPage('페이스북 로그인 페이지로 리디렉트')
 	getFacebookLoginPage() {
-		return true;
+		const facebookeCallbackUrl: string = this.authService.getFacebookLoginPage();
+		return {
+			url: facebookeCallbackUrl,
+		};
 	}
 
+	//Test - facebook
 	@Get('/facebook-callback')
-	@UseGuards(AuthGuard('facebook'))
+	@ApiDocs.facebookLogin2('페이스북 로그인 회원가입&로그인 후 유저 정보, 토큰 반환')
+	async facebookLogin2(@FacebookUser() facebookUser) {
+		// const user: UserResponseDto = await this.authService.createOauthUser(
+		// 	facebookUser as OauthUserDto,
+		// 	UserType.Facebook,
+		// );
+		// return this.authService.login(user);
+	}
+
+	@UseGuards(FacebookAuthGuard)
+	@Post('/facebook-login')
 	@ApiDocs.facebookLogin('페이스북 로그인 회원가입&로그인 후 유저 정보, 토큰 반환')
-	async facebookLogin(@FacebookUser() facebookUser) {
+	async facebookLogin(@Body('facebookUser') facebookUser) {
+		console.log(facebookUser as OauthUserDto);
 		const user: UserResponseDto = await this.authService.createOauthUser(
 			facebookUser as OauthUserDto,
 			UserType.Facebook,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -98,6 +98,14 @@ export class AuthController {
 		return await this.authService.login(user);
 	}
 
+	@Post('/admin-login')
+	@ApiDocs.adminLogin('관리자 로그인')
+	@UseGuards(LocalAuthGuard)
+	@ApiBody({ type: LoginRequestDto })
+	async adminLogin(@AuthUser() user: UserResponseDto) {
+		return await this.authService.adminLogin(user);
+	}
+
 	@UseGuards(JwtRefreshGuard)
 	@Post('token-refresh')
 	@ApiDocs.refreshToken('access token 재발급')

--- a/src/modules/auth/auth.docs.ts
+++ b/src/modules/auth/auth.docs.ts
@@ -5,6 +5,7 @@ import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { AuthCodeRequestDto } from '../auth-codes/dto/auth-code-request.dto';
 import { UserResponseDto } from '../users/dto/user-response.dto';
 import { AuthController } from './auth.controller';
+import { DeleteUserRequestDto } from './dto/delete-user-request.dto';
 import { KakaoLoginRequestDto } from './dto/kakao-login-request.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
@@ -169,6 +170,35 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 			}),
 			ApiBody({
 				type: AuthCodeRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+		);
+	},
+	logout(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '로그아웃',
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: Boolean,
+			}),
+		);
+	},
+	deleteUser(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '회원탈퇴',
+			}),
+			ApiBody({
+				type: DeleteUserRequestDto,
 			}),
 			ApiResponse({
 				status: 201,

--- a/src/modules/auth/auth.docs.ts
+++ b/src/modules/auth/auth.docs.ts
@@ -66,11 +66,44 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 			}),
 		);
 	},
+	facebookLogin2(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '페이스북 서버에서 사용자 정보를 가져와, 회원가입&로그인 후 사용자 정보와 토큰 반환',
+			}),
+			ApiBody({
+				schema: {
+					type: 'object',
+					properties: {
+						code: {
+							description: '페이스북 로그인 code',
+						},
+					},
+				},
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: LoginResponseDto,
+			}),
+		);
+	},
 	facebookLogin(summary: string) {
 		return applyDecorators(
 			ApiOperation({
 				summary,
 				description: '페이스북 서버에서 사용자 정보를 가져와, 회원가입&로그인 후 사용자 정보와 토큰 반환',
+			}),
+			ApiBody({
+				schema: {
+					type: 'object',
+					properties: {
+						code: {
+							description: '페이스북 로그인 code',
+						},
+					},
+				},
 			}),
 			ApiResponse({
 				status: 200,

--- a/src/modules/auth/auth.docs.ts
+++ b/src/modules/auth/auth.docs.ts
@@ -145,6 +145,22 @@ export const ApiDocs: SwaggerMethodDoc<AuthController> = {
 			}),
 		);
 	},
+	adminLogin(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '관리자 로그인',
+			}),
+			ApiBody({
+				type: LoginRequestDto,
+			}),
+			ApiResponse({
+				status: 201,
+				description: '',
+				type: LoginResponseDto,
+			}),
+		);
+	},
 	refreshToken(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -39,6 +39,7 @@ export class AuthService {
 		private readonly mailerService: MailerService,
 	) {}
 	#oauthConfig = this.configService.get<OauthConfig>('oauthConfig').kakao;
+	#facebookConfig = this.configService.get<OauthConfig>('oauthConfig').facebook;
 	#jwtConfig = this.configService.get<JwtConfig>('jwtConfig');
 
 	//Test
@@ -46,6 +47,13 @@ export class AuthService {
 		return `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${
 			this.#oauthConfig.clientId
 		}&redirect_uri=${this.#oauthConfig.callbackUrl}`;
+	}
+
+	//Test
+	getFacebookLoginPage(): string {
+		return `https://www.facebook.com/v2.11/dialog/oauth?client_id=${this.#facebookConfig.clientId}&redirect_uri=${
+			this.#facebookConfig.callbackUrl
+		}`;
 	}
 
 	//Test

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -19,6 +19,7 @@ import { User } from 'src/entities/users.entity';
 import { AuthCodeType } from 'src/types/auth-code.types';
 import { UserType } from 'src/types/users.types';
 import { UserResponseDto } from '../users/dto/user-response.dto';
+import { DeleteUserRequestDto } from './dto/delete-user-request.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { OauthUserDto } from './dto/oauth-user.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';
@@ -214,6 +215,17 @@ export class AuthService {
 		`,
 		});
 		return true;
+	}
+
+	async deleteUser(id: number, passwordData: DeleteUserRequestDto) {
+		const user = await this.usersRepository.findOne({
+			where: { id },
+		});
+
+		if (user.password === passwordData.password) {
+			await this.usersRepository.delete({ id });
+			return true;
+		} else throw new UnauthorizedException('Password is incorrect');
 	}
 
 	async getUserIdIfExist(id: number, role: UserType) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -249,7 +249,7 @@ export class AuthService {
 			where: { id },
 		});
 
-		if (user.password === passwordData.password) {
+		if (await this.isValidPassword(user.password, passwordData.password)) {
 			await this.usersRepository.delete({ id });
 			return true;
 		} else throw new UnauthorizedException('Password is incorrect');

--- a/src/modules/auth/dto/delete-user-request.dto.ts
+++ b/src/modules/auth/dto/delete-user-request.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { LoginRequestDto } from './login-request.dto';
+
+export class DeleteUserRequestDto extends PickType(LoginRequestDto, ['password']) {}

--- a/src/modules/auth/guards/facebook-auth.guard.ts
+++ b/src/modules/auth/guards/facebook-auth.guard.ts
@@ -1,0 +1,27 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { OauthUserDto } from '../dto/oauth-user.dto';
+import { FacebookAuthStrategy } from '../strategies/facebook-auth.strategy';
+
+@Injectable()
+export class FacebookAuthGuard implements CanActivate {
+	constructor(private readonly facebook: FacebookAuthStrategy) {}
+
+	public async canActivate(context: ExecutionContext): Promise<boolean> {
+		const request = context.switchToHttp().getRequest();
+		const code: string = <string>request.body.code;
+		if (!code) throw new UnauthorizedException();
+
+		//code -> accessToken
+		const validateCodeResult: any = await this.facebook.ValidateCode(code);
+		if (!validateCodeResult.id) throw new UnauthorizedException();
+
+		const facebookUser = new OauthUserDto({
+			name: validateCodeResult.last_name + validateCodeResult.first_name,
+			socialId: validateCodeResult.id,
+			email: validateCodeResult.email ? validateCodeResult.email : null,
+		});
+		request.body = { facebookUser: facebookUser };
+
+		return true;
+	}
+}

--- a/src/modules/auth/strategies/facebook-auth.strategy.ts
+++ b/src/modules/auth/strategies/facebook-auth.strategy.ts
@@ -1,30 +1,38 @@
-import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-facebook';
+import { firstValueFrom } from 'rxjs';
 import { OauthConfig } from 'src/config/config.constant';
-import { OauthUserDto } from '../dto/oauth-user.dto';
 
 @Injectable()
-export class FacebookAuthStrategy extends PassportStrategy(Strategy, 'facebook') {
-	constructor(private readonly configService: ConfigService) {
-		const facebookAuthConfig = configService.get<OauthConfig>('oauthConfig').facebook;
-		super({
-			clientID: facebookAuthConfig.clientId,
-			clientSecret: facebookAuthConfig.secretKey,
-			callbackURL: facebookAuthConfig.callbackUrl,
-			scope: 'email',
-			profileFields: ['emails', 'name'],
-		});
-	}
+export class FacebookAuthStrategy {
+	constructor(private readonly httpService: HttpService, private readonly configService: ConfigService) {}
+	#oauthConfig = this.configService.get<OauthConfig>('oauthConfig').facebook;
 
-	async validate(accessToken: string, refreshToken: string, profile: any): Promise<any> {
-		const user = {
-			socialId: parseInt(profile.id),
-			email: profile.emails ? profile.emails[0].value : null,
-			name: profile.name.familyName + profile.name.givenName,
-		};
+	public async ValidateCode(code: string): Promise<any> {
+		const accessTokenApiUrl = `https://graph.facebook.com/v2.11/oauth/access_token?client_id=${
+			this.#oauthConfig.clientId
+		}&redirect_uri=${this.#oauthConfig.callbackUrl}&client_secret=${this.#oauthConfig.secretKey}&code=${code}`;
+		const codeRes = await firstValueFrom(this.httpService.get(accessTokenApiUrl));
+		console.log(codeRes.data);
+		const accessToken: string = codeRes.data.access_token;
 
-		return new OauthUserDto(user);
+		const validateApiUrl = `https://graph.facebook.com/debug_token?input_token=${accessToken}&access_token=${
+			this.#oauthConfig.clientId
+		}|${this.#oauthConfig.secretKey}`;
+		const accessTokenRes = await firstValueFrom(this.httpService.get(validateApiUrl));
+		console.log(accessTokenRes.data);
+		const isValid: boolean = accessTokenRes.data.is_valid;
+
+		if (!isValid) {
+			throw new UnauthorizedException();
+		}
+
+		const userDataApiUrl = `https://graph.facebook.com/me?fields=id,name,email&access_token=${accessToken}`;
+		const userDataRes = await firstValueFrom(this.httpService.get(userDataApiUrl));
+		console.log(userDataRes.data);
+		const userData = userDataRes.data;
+
+		return userData;
 	}
 }


### PR DESCRIPTION
## 개요
- 광고 신청에서 locationId 제거
- 페이스북 로그인 api 수정
- 사용자 로그아웃 api
- 사용자 탈퇴 api
- 관리자 로그인 api
- docker port 번호 수정 (3000 -> 80) : HTTPS 설정 위해
## 작업사항
- GET auth/facebook-login : 테스트용
- GET auth/facebook-callback : 테스트용 (동훈님 계정 있어야 작업할 수 있어 아직 구현안함)
- POST auth/facebook-login : 클라이언트에게서 code를 받아, 이를 facebook api에 전달해 사용자 정보 가져오기 & 로그인
- POST auth/admin-login : 관지라 로그인
- POST auth/logout : 로그아웃
- POST auth/resign : 회원탈퇴
## 테스트
- 사용자 로그아웃, 탈퇴, 관리자 로그인 api 테스트 (일반 사용자 제대로 막아지는지)
- 페이스북 로그인 부분은 아직 제대로 구현되어 있지 않아, 테스트가 불가 (추후에 수정 예정)