### PR TITLE
Feat: Posts sorting addition & posts list with order

### DIFF
--- a/src/modules/posts/dto/main-posts-request.dto.ts
+++ b/src/modules/posts/dto/main-posts-request.dto.ts
@@ -15,7 +15,7 @@ export class MainPostsRequestDto {
 	@ApiProperty({
 		enum: PostsSortType,
 		default: PostsSortType.CreatedAt,
-		description: '정렬 기준 (최신순: CreatedAt)',
+		description: '정렬 기준 (최신순: CreatedAt, 조회순: View, 인기순: Like)',
 	})
 	readonly sorter?: PostsSortType = PostsSortType.CreatedAt;
 

--- a/src/modules/posts/dto/main-posts-response.dto.ts
+++ b/src/modules/posts/dto/main-posts-response.dto.ts
@@ -8,6 +8,10 @@ export class MainPostsResponseDto {
 	@ApiProperty({ example: 1, description: '커뮤니티 게시글 id' })
 	readonly id: number;
 
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '커뮤니티 게시글 순서' })
+	readonly order: number;
+
 	@IsString()
 	@ApiProperty({ example: 'test', description: '제목' })
 	readonly title: string;
@@ -42,8 +46,9 @@ export class MainPostsResponseDto {
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })
 	readonly photoUrls: string[];
 
-	constructor({ id, title, user, address, createdAt, views, likes, isLike, location, photoUrls }) {
+	constructor({ id, order, title, user, address, createdAt, views, likes, isLike, location, photoUrls }) {
 		this.id = id;
+		this.order = order;
 		this.title = title;
 		this.user = user;
 		this.address = address;

--- a/src/modules/posts/posts.docs.ts
+++ b/src/modules/posts/posts.docs.ts
@@ -236,7 +236,7 @@ export const ApiDocs: SwaggerMethodDoc<PostsController> = {
 			ApiQuery({
 				name: 'sorter',
 				required: false,
-				description: '정렬 기준 (최신순: CreatedAt)',
+				description: '정렬 기준 (최신순: CreatedAt, 조회순: View, 인기순: Like)',
 			}),
 			ApiQuery({
 				name: 'page',

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -15,6 +15,7 @@ import { Post } from 'src/entities/posts.entity';
 import { ReportPost } from 'src/entities/report-posts.entity';
 import { Theme } from 'src/entities/theme.entity';
 import { UserType } from 'src/types/users.types';
+import { PostsSortType } from 'src/types/posts-sort.types';
 import { AdFormsService } from '../ad-forms/ad-forms.service';
 import { LocationResponseDto } from '../filters/dto/location-response.dto';
 import { CommentsUserResponseDto } from '../users/dto/comments-user-response.dto';
@@ -490,9 +491,33 @@ export class PostsService {
 				.createQueryBuilder('post')
 				.leftJoinAndSelect('post.location', 'location')
 				.leftJoinAndSelect('post.user', 'user')
-				.leftJoinAndSelect('post.clickPosts', 'clickPosts')
-				.leftJoinAndSelect('post.likePosts', 'likePosts')
-				.orderBy(`post.${searchRequest.sorter}`, 'ASC');
+				.select(
+					'post.id AS id, post.title AS title, post.address AS address, post.createdAt AS create, post.photoUrls AS photos',
+				)
+				.addSelect('location.id AS location, location.metroName AS metro, location.localName AS local')
+				.addSelect('user.id AS user, user.nickname AS name')
+				.addSelect((clicks) => {
+					return clicks
+						.select('COUNT (*)', 'clickPosts')
+						.from(ClickPost, 'clickPosts')
+						.where('clickPosts.postId = post.id')
+						.limit(1);
+				}, 'clicks')
+				.addSelect((likes) => {
+					return likes
+						.select('COUNT (*)', 'likePosts')
+						.from(LikePost, 'likePosts')
+						.where('likePosts.postId = post.id')
+						.limit(1);
+				}, 'likes')
+				.addSelect((likeUsers) => {
+					return likeUsers
+						.select('likePosts.id', 'likePosts')
+						.from(LikePost, 'likePosts')
+						.where('likePosts.postId = post.id')
+						.andWhere('likePosts.userId = :user', { user: userId })
+						.limit(1);
+				}, 'likeUsers');
 
 			if (searchRequest.word) {
 				posts = posts.where('post.title Like :title', { title: `%${searchRequest.word}%` });
@@ -505,7 +530,6 @@ export class PostsService {
 
 				posts = posts.andWhere('location.id IN (:...locationIds)', { locationIds: locationIds });
 			}
-
 			if (searchRequest.themeIds) {
 				posts = posts
 					.leftJoinAndSelect('post.postThemes', 'postThemes')
@@ -513,11 +537,15 @@ export class PostsService {
 					.andWhere('theme.id IN (:...themeIds)', { themeIds: searchRequest.themeIds });
 			}
 
+			if (searchRequest.sorter === PostsSortType.View) posts = posts.orderBy('clicks', 'DESC');
+			else if (searchRequest.sorter === PostsSortType.Like) posts = posts.orderBy('likes', 'DESC');
+			else if (searchRequest.sorter === PostsSortType.CreatedAt) posts = posts.orderBy('post.createdAt', 'DESC');
+
 			const totalPagePosts = await posts.getMany();
 			const responsePosts = await posts
 				.limit(searchRequest.take)
 				.offset((searchRequest.page - 1) * searchRequest.take)
-				.getMany();
+				.getRawMany();
 
 			let order = responsePosts.length;
 			const totalPage = Math.ceil(totalPagePosts.length / searchRequest.take);
@@ -526,11 +554,17 @@ export class PostsService {
 					new MainPostsResponseDto({
 						...post,
 						order: order--,
-						views: post.clickPosts.length,
-						likes: post.likePosts.length,
-						isLike: this.isLikePost(userId, post.likePosts) ? true : false,
-						user: new CommentsUserResponseDto(post.user),
-						location: new LocationResponseDto(post.location),
+						views: +post.clicks,
+						likes: +post.likes,
+						createdAt: post.create,
+						photoUrls: post.photos,
+						isLike: post.likeUsers ? true : false,
+						user: new CommentsUserResponseDto({ id: post.user, nickname: post.name }),
+						location: new LocationResponseDto({
+							id: post.location,
+							metroName: post.metro,
+							localName: post.local,
+						}),
 					}),
 			);
 			return new MainPostsPageResponseDto({ totalPage: totalPage, posts: postsDto });

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -541,7 +541,7 @@ export class PostsService {
 			else if (searchRequest.sorter === PostsSortType.Like) posts = posts.orderBy('likes', 'DESC');
 			else if (searchRequest.sorter === PostsSortType.CreatedAt) posts = posts.orderBy('post.createdAt', 'DESC');
 
-			const totalPagePosts = await posts.getMany();
+			const totalPagePosts = await posts.getRawMany();
 			const responsePosts = await posts
 				.limit(searchRequest.take)
 				.offset((searchRequest.page - 1) * searchRequest.take)

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -519,11 +519,13 @@ export class PostsService {
 				.offset((searchRequest.page - 1) * searchRequest.take)
 				.getMany();
 
+			let order = responsePosts.length;
 			const totalPage = Math.ceil(totalPagePosts.length / searchRequest.take);
 			const postsDto = Array.from(responsePosts).map(
 				(post) =>
 					new MainPostsResponseDto({
 						...post,
+						order: order--,
 						views: post.clickPosts.length,
 						likes: post.likePosts.length,
 						isLike: this.isLikePost(userId, post.likePosts) ? true : false,

--- a/src/types/posts-sort.types.ts
+++ b/src/types/posts-sort.types.ts
@@ -1,3 +1,5 @@
 export enum PostsSortType {
-	CreatedAt = 'Created_At',
+	CreatedAt = 'CreatedAt',
+	View = 'View',
+	Like = 'Like',
 }


### PR DESCRIPTION
## 작업사항
- 커뮤니티 게시판 리스트 순서 추가하였습니다.
- 커뮤니티 게시판 조회순, 좋아요 순 정렬 추가하였습니다.

## 테스트
- 커뮤니티 게시판 순서가 잘 나타나는지 (필터링 했을 때도), 정렬이 잘 되는지 확인