### PR TITLE
Fix: Location & theme filtering and return address instead of location

### DIFF
--- a/src/modules/admins/admins.service.ts
+++ b/src/modules/admins/admins.service.ts
@@ -106,7 +106,7 @@ export class AdminsService {
 	async getAdsFilter(getAdRequest?: GetAdFilterRequestDto) {
 		try {
 			const ads = this.adsRepository.createQueryBuilder('ad');
-			if (getAdRequest.locationIds) {
+			if (getAdRequest.locationIds && getAdRequest.locationIds[0] !== 0) {
 				let locationIds = getAdRequest.locationIds;
 				const allSelection = await this.allSelection(locationIds);
 				const localsIds = allSelection.flatMap(({ id }) => [id]);

--- a/src/modules/posts/dto/main-posts-response.dto.ts
+++ b/src/modules/posts/dto/main-posts-response.dto.ts
@@ -39,14 +39,11 @@ export class MainPostsResponseDto {
 	@ApiProperty({ example: false, description: '게시글 좋아요 여부' })
 	readonly isLike: boolean;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
-
 	@IsArray()
 	@ApiProperty({ isArray: true, example: ['test'], description: '사진 url 리스트' })
 	readonly photoUrls: string[];
 
-	constructor({ id, order, title, user, address, createdAt, views, likes, isLike, location, photoUrls }) {
+	constructor({ id, order, title, user, address, createdAt, views, likes, isLike, photoUrls }) {
 		this.id = id;
 		this.order = order;
 		this.title = title;
@@ -56,7 +53,6 @@ export class MainPostsResponseDto {
 		this.views = views;
 		this.likes = likes;
 		this.isLike = isLike;
-		this.location = new LocationResponseDto(location);
 		this.photoUrls = photoUrls;
 	}
 }

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -494,7 +494,6 @@ export class PostsService {
 				.select(
 					'post.id AS id, post.title AS title, post.address AS address, post.createdAt AS create, post.photoUrls AS photos',
 				)
-				.addSelect('location.id AS location, location.metroName AS metro, location.localName AS local')
 				.addSelect('user.id AS user, user.nickname AS name')
 				.addSelect((clicks) => {
 					return clicks
@@ -522,7 +521,7 @@ export class PostsService {
 			if (searchRequest.word) {
 				posts = posts.where('post.title Like :title', { title: `%${searchRequest.word}%` });
 			}
-			if (searchRequest.locationIds) {
+			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;
 				const allMetros = await this.allSelection(locationIds);
 				const localsIds = Array.from(allMetros).flatMap(({ id }) => [id]);
@@ -530,7 +529,7 @@ export class PostsService {
 
 				posts = posts.andWhere('location.id IN (:...locationIds)', { locationIds: locationIds });
 			}
-			if (searchRequest.themeIds) {
+			if (searchRequest.themeIds && searchRequest.themeIds[0] !== 0) {
 				posts = posts
 					.leftJoinAndSelect('post.postThemes', 'postThemes')
 					.leftJoinAndSelect('postThemes.theme', 'theme')
@@ -560,11 +559,6 @@ export class PostsService {
 						photoUrls: post.photos,
 						isLike: post.likeUsers ? true : false,
 						user: new CommentsUserResponseDto({ id: post.user, nickname: post.name }),
-						location: new LocationResponseDto({
-							id: post.location,
-							metroName: post.metro,
-							localName: post.local,
-						}),
 					}),
 			);
 			return new MainPostsPageResponseDto({ totalPage: totalPage, posts: postsDto });

--- a/src/modules/ranks/dto/ranking-list-response.dto.ts
+++ b/src/modules/ranks/dto/ranking-list-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
-import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
-
 export class RankingListResponseDto {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -11,6 +9,10 @@ export class RankingListResponseDto {
 	@IsString()
 	@ApiProperty({ example: '을왕리해수욕장', description: '여행지 이름' })
 	readonly name: string;
+
+	@IsString()
+	@ApiProperty({ example: '인천 옹진군 자월면 승봉로29번길 15', description: '주소 이름' })
+	readonly address: string;
 
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '순위' })
@@ -32,17 +34,14 @@ export class RankingListResponseDto {
 	@ApiProperty({ example: 'https://scontent~', description: '여행지 사진 링크' })
 	readonly photoUrl: string;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
-
-	constructor({ id, name, rank, variance, views, wishes, photoUrl, location }) {
+	constructor({ id, name, address, rank, variance, views, wishes, photoUrl }) {
 		this.id = id;
 		this.name = name;
+		this.address = address;
 		this.rank = rank;
 		this.variance = variance;
 		this.views = views;
 		this.wishes = wishes;
 		this.photoUrl = photoUrl;
-		this.location = new LocationResponseDto(location);
 	}
 }

--- a/src/modules/ranks/dto/ranking-map-response.dto.ts
+++ b/src/modules/ranks/dto/ranking-map-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
-import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
-
 export class RankingMapResponseDto {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -24,15 +22,16 @@ export class RankingMapResponseDto {
 	@ApiProperty({ example: 126.234523, description: '경도' })
 	readonly longitude: number;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
+	@IsString()
+	@ApiProperty({ example: '인천 옹진군 자월면 승봉로29번길 15', description: '주소 이름' })
+	readonly address: string;
 
-	constructor({ id, name, rank, latitude, longitude, location }) {
+	constructor({ id, name, rank, latitude, longitude, address }) {
 		this.id = id;
 		this.name = name;
 		this.rank = rank;
 		this.latitude = latitude;
 		this.longitude = longitude;
-		this.location = new LocationResponseDto(location);
+		this.address = address;
 	}
 }

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -60,7 +60,7 @@ export class RanksService {
 				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
-				.select('spot.id AS id, spot.name AS name')
+				.select('spot.id AS id, spot.name AS name, spot.address AS address')
 				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
 				.addSelect((afterRank) => {
 					return afterRank
@@ -112,11 +112,6 @@ export class RanksService {
 					views: +spot.clicks,
 					wishes: +spot.wishes,
 					photoUrl: spot.photo,
-					location: new LocationResponseDto({
-						id: spot.location_id,
-						metroName: spot.metro,
-						localName: spot.local,
-					}),
 				});
 			});
 		} catch (error) {
@@ -134,7 +129,9 @@ export class RanksService {
 				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
-				.select('spot.id AS id, spot.name AS name, spot.latitude AS latitude, spot.longitude AS longitude')
+				.select(
+					'spot.id AS id, spot.name AS name, spot.latitude AS latitude, spot.longitude AS longitude, spot.address AS address',
+				)
 				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
 				.addSelect((currentRank) => {
 					return currentRank
@@ -152,11 +149,6 @@ export class RanksService {
 					new RankingMapResponseDto({
 						...spot,
 						rank: spot.current_rank,
-						location: new LocationResponseDto({
-							id: spot.location_id,
-							metroName: spot.metro,
-							localName: spot.local,
-						}),
 					}),
 			);
 		} catch (error) {

--- a/src/modules/spots/dto/detail-spot-response.dto.ts
+++ b/src/modules/spots/dto/detail-spot-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsBoolean, IsNumber, IsString } from 'class-validator';
 
-import { LocationResponseDto } from 'src/modules/filters/dto/location-response.dto';
-
 export class DetailSpotResponseDto<S, N> {
 	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
@@ -36,8 +34,9 @@ export class DetailSpotResponseDto<S, N> {
 	@ApiProperty({ example: false, description: '여행지 찜하기 여부' })
 	readonly isWish: boolean;
 
-	@ApiProperty({ description: '위치 정보' })
-	readonly location: LocationResponseDto;
+	@IsString()
+	@ApiProperty({ example: '인천 옹진군 자월면 승봉로29번길 15', description: '주소 이름' })
+	readonly address: string;
 
 	@IsArray()
 	@ApiProperty({ isArray: true, example: '관련 sns 게시글 정보' })
@@ -56,7 +55,7 @@ export class DetailSpotResponseDto<S, N> {
 		views,
 		wishes,
 		isWish,
-		location,
+		address,
 		detailSnsPost,
 		neaybyFacility,
 	}) {
@@ -65,10 +64,10 @@ export class DetailSpotResponseDto<S, N> {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.snsPostLikeNumber = snsPostLikeNumber;
+		this.address = address;
 		this.views = views;
 		this.wishes = wishes;
 		this.isWish = isWish;
-		this.location = new LocationResponseDto(location);
 		this.detailSnsPost = detailSnsPost;
 		this.neaybyFacility = neaybyFacility;
 	}

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -312,7 +312,7 @@ export class SpotsService {
 			if (searchRequest.word) {
 				searchSpots = searchSpots.where('spot.name Like :name', { name: `%${searchRequest.word}%` });
 			}
-			if (searchRequest.locationIds) {
+			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;
 				const allMetros = await this.allSelection(locationIds);
 				const localsIds = Array.from(allMetros).flatMap(({ id }) => [id]);
@@ -321,9 +321,8 @@ export class SpotsService {
 					.leftJoinAndSelect('spot.location', 'location')
 					.andWhere('location.id IN (:...locationIds)', { locationIds: locationIds });
 			}
-			if (searchRequest.themeIds) {
+			if (searchRequest.themeIds && searchRequest.themeIds[0] !== 0) {
 				searchSpots = searchSpots
-					.leftJoinAndSelect('spot.snsPosts', 'snsPosts')
 					.leftJoinAndSelect('snsPosts.theme', 'theme')
 					.andWhere('theme.id IN (:...themeIds)', { themeIds: searchRequest.themeIds });
 			}
@@ -392,7 +391,6 @@ export class SpotsService {
 				.limit(detailRequest.take)
 				.getMany();
 			const detailSnsPostsDto = Array.from(detailSnsPosts).map((post) => new DetailSnsPostResponseDto(post));
-			const location = await this.locationsRepository.findOne({ where: { id: IsSpot.locationId } });
 			const facilitiesDto = await this.getNearbyFacility(IsSpot.latitude, IsSpot.longitude);
 			return new DetailSpotResponseDto({
 				...IsSpot,
@@ -401,7 +399,6 @@ export class SpotsService {
 				wishes: IsSpot.wishSpots.length,
 				detailSnsPost: detailSnsPostsDto,
 				neaybyFacility: facilitiesDto,
-				location: new LocationResponseDto(location),
 			});
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);


### PR DESCRIPTION
## 작업사항
- post list, ranking list, spot list, spot detail 전부 location 대신에 address 반환하도록 수정하였습니다.
- location filtering, theme filtering 이슈 해결하였습니다.

## 테스트
- post/ranking/spot list, spot 상세페이지 address 확인
- spot, post, ad filtering 확인