### PR TITLE
Feat: Design ad register and edit page & Link API

### DIFF
--- a/src/public/css/ad.css
+++ b/src/public/css/ad.css
@@ -1,0 +1,312 @@
+* {
+	box-sizing: border-box;
+	font-family: 'Nanum Gothic', sans-serif;
+}
+
+body {
+	margin: 0;
+	background-color: #f2f2f2;
+	overflow: auto;
+}
+
+.home {
+	text-align: center;
+	background: #4d377b;
+	color: #fff;
+	padding-top: 25px;
+	padding-bottom: 25px;
+	font-size: 16px;
+	font-weight: 600;
+	border-bottom: 2px solid white;
+}
+
+.home a {
+	color: #fff;
+	font-size: 16px;
+	font-weight: 600;
+}
+
+ul,
+li {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+a {
+	text-decoration: none;
+}
+
+.container {
+	position: fixed;
+	width: 260px;
+	background: white;
+	height: 100%;
+	overflow: auto;
+	box-shadow: 0 5px 10px rgba(35, 0, 77, 0.2);
+	z-index: 1;
+}
+#menu li a {
+	position: relative;
+	display: block;
+	height: 50px;
+	line-height: 50px;
+	border-bottom: 1px solid #eee;
+	text-align: left;
+	font-size: 14px;
+	font-weight: bold;
+	color: #5f5f5f;
+	padding-left: 10px;
+}
+
+#menu li a:hover {
+	background-color: rgba(198, 128, 255, 0.2);
+	color: #4d377b;
+	border-radius: 5px;
+}
+
+#menu .sub_menu {
+	display: none;
+}
+#menu .sub_menu a {
+	background-color: rgba(204, 204, 204, 0.2);
+	color: #5f5f5f;
+	font-size: 12px;
+}
+#menu .sub_menu a:hover {
+	background-color: rgba(198, 128, 255, 0.4);
+	color: #4d377b;
+}
+
+.header {
+	position: fixed;
+	width: 100%;
+	background-color: white;
+	height: 70px;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+	padding-top: 20px;
+	z-index: 1;
+}
+
+.material-symbols-outlined {
+	float: right;
+	font-size: 22px;
+	color: gray;
+	cursor: pointer;
+	text-align: right;
+	margin-right: 30px;
+	margin-top: 5px;
+}
+
+#admin_page {
+	font-size: 24px;
+	font-weight: bolder;
+	color: #4d377b;
+	text-align: left;
+	margin-left: 280px;
+	margin-bottom: 20px;
+}
+
+.material-symbols-outlined:hover {
+	font-size: 25px;
+	color: #4d377b;
+}
+
+.ad {
+	padding-top: 100px;
+	padding-left: 350px;
+}
+
+.ad a {
+	font-size: 14px;
+	font-weight: 600;
+	color: #4d377b;
+}
+
+#list_table {
+	width: 900px;
+	border-radius: 8px;
+	border-collapse: collapse;
+	margin-top: 10px;
+	margin-bottom: 50px;
+	text-align: center;
+}
+
+#list_table tr {
+	border-top: #d3d3d3 solid 1px;
+}
+
+#list_table tr:nth-child(odd) {
+	background-color: white;
+}
+
+#list_table tr:nth-child(even) {
+	background-color: #ebe7f1;
+}
+
+#list_table th,
+td {
+	padding: 15px 30px;
+}
+
+#list_table th {
+	background-color: #4d377b;
+	color: white;
+	font-size: 14px;
+	font-weight: 700;
+}
+
+#list_table td {
+	font-size: 12px;
+	color: black;
+	font-weight: bold;
+}
+
+#list_table .detail-link {
+	font-size: 14px;
+	color: #4d377b;
+	font-weight: bold;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+	margin-top: 10px;
+	padding-right: 10px;
+	float: left;
+}
+
+.dataTables_filter {
+	float: left;
+	margin-bottom: 10px;
+	font-size: 16px;
+	font-weight: bolder;
+}
+
+.dataTables_info {
+	text-align: left !important;
+	color: #5f5f5f;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.popup {
+	display: none;
+	width: 800px;
+	height: 500px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	background-color: #fff;
+	z-index: 2;
+	border-radius: 10px;
+	overflow-y: auto;
+	font-size: 14px;
+	font-weight: bold;
+}
+
+.popup-detail {
+	margin: -250px 0 0 -350px;
+	text-align: center;
+}
+
+.popup-register {
+	width: 500px;
+	height: 400px;
+	margin: -250px 0 0 -150px;
+}
+
+.modal-header {
+	color: #fff;
+	background-color: #4d377b;
+	padding-top: 15px;
+	padding-bottom: 15px;
+	margin-bottom: 20px;
+	text-align: center;
+}
+
+.modal-title {
+	font-size: 18px;
+	font-weight: 800;
+}
+
+.input {
+	margin-bottom: 5px;
+}
+
+.modal-body div {
+	padding: 10px;
+}
+
+.ad-register-body {
+	margin-left: 20px;
+}
+
+.ad-register-body div {
+	text-align: center;
+}
+
+.modal-footer {
+	margin: 20px;
+}
+
+.input {
+	margin-left: 10px;
+	width: 200px;
+	height: 25px;
+	border: 1px solid #5f5f5f;
+	border-radius: 3px;
+}
+
+.btn-update,
+.btn-register {
+	margin-bottom: 15px;
+	background-color: white;
+}
+
+.btn {
+	cursor: pointer;
+	display: inline-block;
+	border-radius: 3px;
+	border: 1px solid #4d377b;
+	box-shadow: 0 5px 10px -5px rgba(35, 0, 77, 0.2);
+	font-size: 12px;
+	font-weight: 600;
+	padding: 6px 12px;
+}
+
+.btn:hover {
+	border: none;
+	background-color: #4d377b;
+	color: white;
+	font-size: 13px;
+}
+
+.btn-delete {
+	border: 1px solid red;
+	color: red;
+	padding: 6px 12px;
+	float: right;
+	background-color: white;
+}
+
+.btn-delete:hover {
+	background-color: red;
+}
+
+.backon {
+	content: '';
+	width: 100%;
+	height: 100%;
+	background: #00000054;
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 1;
+}
+
+.close {
+	float: right;
+	cursor: pointer;
+	font-size: 16px;
+	font-weight: 600;
+	margin-right: 15px;
+}

--- a/src/public/js/ad-request.js
+++ b/src/public/js/ad-request.js
@@ -60,7 +60,7 @@ $(document).ready(function () {
 				],
 				fnDrawCallback: function () {
 					if ($(this).find('.dataTables_empty').length == 1) {
-						empty = 'true';
+						$('.ad-request').hide();
 					}
 				},
 				ordering: true,
@@ -88,38 +88,39 @@ $(document).ready(function () {
 	});
 
 	$('#list_table').on('click', 'td', function () {
-		if (empty != 'true') {
+		var row_data = table.row(this).data();
+		if (typeof row_data != 'undefined') {
 			$('#popup').show();
 			$('.modal-body').empty();
-			var row_data = table.row(this).data();
-			var data_list = '';
-			console.log(row_data.id); //row_data 확인
-			$.ajax({
-				url: '/admins/ad-forms/' + row_data.id,
-				type: 'GET',
-				dataType: 'json',
-				dataSrc: '',
-				headers: { Authorization: 'Bearer ' + accessToken },
-				success: function (adform) {
-					console.log(adform);
-					var img_data = '<img src="' + adform.licenseUrl + '" alt="license">';
-					$('.modal-body').append('<div> 회사명 : ' + adform.businessName + '</div>');
-					$('.modal-body').append('<div> 위치 : ' + adform.address + '</div>');
-					$('.modal-body').append('<div> 이메일 : ' + adform.email + '</div>');
-					if (adform.phoneNumber != null) {
-						$('.modal-body').append('<div> 전화번호 : ' + adform.phoneNumber + '</div>');
-					}
-					$('.modal-body').append('<div> 상태 : ' + adform.status + '</div>');
-					$('.modal-body').append('<div>사업자 등록증</div>');
-					$('.modal-body').append(img_data);
-					$('#popup').append(data_list);
-					$('body').append('<div class="backon"></div>');
-				},
-				error: function (response) {
-					alert(response.responseText);
-				},
-			});
 		}
+		var data_list = '';
+		console.log(row_data.id); //row_data 확인
+		$.ajax({
+			url: '/admins/ad-forms/' + row_data.id,
+			type: 'GET',
+			dataType: 'json',
+			dataSrc: '',
+			headers: { Authorization: 'Bearer ' + accessToken },
+			success: function (adform) {
+				console.log(adform);
+				var img_data = '<img src="' + adform.licenseUrl + '" alt="license">';
+				$('.modal-body').append('<div> 회사명 : ' + adform.businessName + '</div>');
+				$('.modal-body').append('<div> 위치 : ' + adform.address + '</div>');
+				$('.modal-body').append('<div> 이메일 : ' + adform.email + '</div>');
+				if (adform.phoneNumber != null) {
+					$('.modal-body').append('<div> 전화번호 : ' + adform.phoneNumber + '</div>');
+				}
+				$('.modal-body').append('<div> 상태 : ' + adform.status + '</div>');
+				$('.modal-body').append('<div>사업자 등록증</div>');
+				$('.modal-body').append(img_data);
+				$('#popup').append(data_list);
+				$('body').append('<div class="backon"></div>');
+			},
+			error: function (response) {
+				alert(response.responseText);
+			},
+		});
+
 		$('.btn-approve').click(function () {
 			var result = confirm("해당 광고의 상태를 'approve'로 변경하시겠습니까?");
 			if (result) {

--- a/src/public/js/ad-request.js
+++ b/src/public/js/ad-request.js
@@ -204,7 +204,6 @@ $(document).ready(function () {
 				});
 				$('#popup').hide();
 				$('.backon').hide();
-				location.reload();
 			} else {
 			}
 		});

--- a/src/public/js/ad-request.js
+++ b/src/public/js/ad-request.js
@@ -196,6 +196,7 @@ $(document).ready(function () {
 					headers: { Authorization: 'Bearer ' + accessToken },
 					success: function (data) {
 						alert('삭제 완료!');
+						window.location.reload();
 					},
 					error: function (data) {
 						console.log(data);

--- a/src/public/js/ad.js
+++ b/src/public/js/ad.js
@@ -1,0 +1,297 @@
+$(document).ready(function () {
+	var accessToken = localStorage.getItem('accessToken');
+	var empty;
+	$.ajax({
+		url: '/users/admin-test',
+		type: 'Get',
+		headers: { Authorization: 'Bearer ' + accessToken },
+		success: function (data) {},
+		error: function (data) {
+			alert('관리자 권한이 필요합니다.');
+			window.location.href = '/admin/login';
+		},
+	});
+
+	$('.main_menu').click(function () {
+		$('.sub_menu').slideUp();
+		if ($(this).children('.sub_menu').is(':hidden')) {
+			$(this).children('.sub_menu').slideDown();
+		} else {
+			$(this).children('.sub_menu').slideUp();
+		}
+	});
+
+	$.ajax({
+		url: '/admins/adsAll',
+		type: 'Get',
+		dataType: 'json',
+		dataSrc: '',
+		headers: { Authorization: 'Bearer ' + accessToken },
+		success: function (response) {
+			table = $('#list_table').DataTable({
+				data: response,
+				columns: [
+					{
+						data: null,
+						render: function (data, type, row, meta) {
+							return meta.row + meta.settings._iDisplayStart + 1;
+						},
+					},
+					{ data: 'businessName' },
+					{ orderable: false, data: 'email' },
+					{
+						data: null,
+						title: 'DATE',
+						width: 100,
+						render: function (data) {
+							let date = '' + data.createdAt;
+							return date.substring(0, 10);
+						},
+					},
+					{
+						orderable: false,
+						data: null,
+						render: function (data) {
+							return '<a href="#" class="detail-link">DETAIL</a>';
+						},
+					},
+				],
+				fnDrawCallback: function () {
+					if ($(this).find('.dataTables_empty').length == 1) {
+						empty = 'true';
+					}
+				},
+				ordering: true,
+				lengthChange: false,
+				pagingType: 'full_numbers',
+				info: true,
+				autoWidth: false,
+			});
+		},
+		error: function (response) {
+			console.log(response.responseText);
+		},
+	});
+
+	$('body').on('click', function (event) {
+		if (event.target.className == 'close' || event.target.className == 'backon') {
+			$('.popup').hide();
+			$('.backon').hide();
+			location.reload();
+		}
+	});
+
+	$('.btn-register').click(function () {
+		$('.popup-register').show();
+		$('body').append('<div class="backon"></div>');
+		$('.btn-submit').click(function () {
+			var result = confirm('정말로 등록하시겠습니까?');
+			var form = $('#ad-register')[0];
+			var formData = new FormData(form);
+			var isEmpty = false;
+			if (result) {
+				$('#ad-register')
+					.find('input[type!="hidden"]')
+					.each(function () {
+						if (!$(this).val()) {
+							isEmpty = true;
+						}
+					});
+
+				if (isEmpty) {
+					alert('데이터를 전부 입력해주세요!');
+					return false;
+				}
+
+				$.ajax({
+					cache: false,
+					url: '/admins/ads',
+					type: 'POST',
+					processData: false,
+					contentType: false,
+					data: formData,
+					headers: { Authorization: 'Bearer ' + accessToken },
+					success: function (data) {
+						alert('등록 완료!');
+						console.log(formData);
+					},
+					error: function (data) {
+						alert('유효한 값을 입력해주세요!');
+					},
+				});
+			} else {
+			}
+		});
+	});
+
+	$('#list_table').on('click', 'td', function () {
+		if (empty != 'true') {
+			$('.popup-detail').show();
+			$('.ad-body').empty();
+			var row_data = table.row(this).data();
+
+			$.ajax({
+				url: '/admins/ads/' + row_data.id,
+				type: 'GET',
+				dataType: 'json',
+				dataSrc: '',
+				headers: { Authorization: 'Bearer ' + accessToken },
+				success: function (adform) {
+					var img_data = '<img src="' + adform.photoUrl + '" alt="license">';
+					$('.modal-body').append('<div> 회사명 : ' + adform.businessName + '</div>');
+					$('.modal-body').append('<div> 위치 : ' + adform.address + '</div>');
+					$('.modal-body').append('<div> 이메일 : ' + adform.email + '</div>');
+					$('.modal-body').append(
+						'<div> 홈페이지 : <a href = "' +
+							adform.pageUrl +
+							'" target="_blank">' +
+							adform.pageUrl +
+							'</a></div>',
+					);
+					$('.modal-body').append('<div>광고 배너</div>');
+					$('.modal-body').append(img_data);
+					$('body').append('<div class="backon"></div>');
+				},
+				error: function (response) {
+					alert(response.responseText);
+				},
+			});
+		}
+
+		$('.btn-edit').click(function () {
+			$('.ad-body').empty();
+			$('.ad-footer').hide();
+			$.ajax({
+				url: '/admins/ads/' + row_data.id,
+				type: 'GET',
+				dataType: 'json',
+				dataSrc: '',
+				headers: { Authorization: 'Bearer ' + accessToken },
+				success: function (ad) {
+					$('.modal-body').append('<form id="ad-edit">');
+					$('.modal-body').append(
+						'<div> 회사명 : <input class="input input-business" type="text" name="businessName" placeholder="' +
+							ad.businessName +
+							'" /> </div>',
+					);
+					$('.modal-body').append(
+						'<div> 이메일 : <input class="input input-email" type="email" name="email" placeholder="' +
+							ad.email +
+							'" /> </div>',
+					);
+					$('.modal-body').append(
+						'<div> 홈페이지 : <input class="input input-page" type="text" name="pageUrl" placeholder="' +
+							ad.pageUrl +
+							'" /> </div>',
+					);
+					$('.modal-body').append(
+						'<div> 주소 : <input class="input input-address" type="text" name="address" placeholder="' +
+							ad.address +
+							'" /> </div>',
+					);
+					$('.modal-body').append(
+						'<div> 배너 수정 : <input class="input input-file" type="file" name="file"/> </div>',
+					);
+
+					$('.modal-body').append('<button class="btn edit-complete" type="button">수정</button>');
+					$('.modal-body').append('</form>');
+				},
+			});
+
+			$(document).on('click', '.edit-complete', function (e) {
+				e.preventDefault();
+				var result = confirm('정말로 수정하시겠습니까?');
+
+				var form = new FormData();
+
+				if ($('.input-business').val() != '') {
+					form.append('businessName', $('.input-business').val());
+				}
+
+				if ($('.input-email').val() != '') {
+					form.append('email', $('.input-email').val());
+				}
+
+				if ($('.input-page').val() != '') {
+					form.append('pageUrl', $('.input-page').val());
+				}
+
+				if ($('.input-address').val() != '') {
+					form.append('address', $('.input-address').val());
+				}
+
+				if ($('.input-file').val()) {
+					form.append('file', $('.input-file')[0].files[0]);
+				}
+
+				for (let key of form.keys()) {
+					console.log(key);
+				}
+
+				for (let value of form.values()) {
+					console.log(value);
+				}
+
+				if (result) {
+					$.ajax({
+						url: '/admins/ads/' + row_data.id,
+						type: 'PATCH',
+						processData: false,
+						contentType: false,
+						data: form,
+						headers: { Authorization: 'Bearer ' + accessToken },
+						success: function (data) {
+							alert('변경 완료!');
+						},
+						error: function (data) {
+							alert('유효한 값을 입력해주세요!');
+						},
+					});
+				}
+			});
+		});
+
+		$('.btn-delete').click(function () {
+			var result = confirm('해당 광고를 정말로 삭제하시겠습니까?');
+			if (result) {
+				$.ajax({
+					url: '/admins/ads/' + row_data.id,
+					type: 'DELETE',
+					processData: false,
+					data: '',
+					headers: { Authorization: 'Bearer ' + accessToken },
+					success: function (data) {
+						alert('삭제 완료!');
+					},
+					error: function (data) {
+						console.log(data);
+					},
+				});
+				$('.popup').hide();
+				$('.backon').hide();
+				location.reload();
+			} else {
+			}
+		});
+	});
+
+	$('.logout').click(function () {
+		$.ajax({
+			url: '/auth/logout',
+			type: 'POST',
+			headers: { Authorization: 'Bearer ' + accessToken },
+			success: function (data) {
+				localStorage.clear();
+				alert('로그아웃 성공!');
+				location.reload();
+			},
+			error: function (data) {
+				console.log(data);
+			},
+		});
+	});
+
+	$('.btn-update').click(function () {
+		location.reload();
+	});
+});

--- a/src/public/js/ad.js
+++ b/src/public/js/ad.js
@@ -1,6 +1,7 @@
 $(document).ready(function () {
 	var accessToken = localStorage.getItem('accessToken');
 	var empty;
+
 	$.ajax({
 		url: '/users/admin-test',
 		type: 'Get',
@@ -113,13 +114,19 @@ $(document).ready(function () {
 					headers: { Authorization: 'Bearer ' + accessToken },
 					success: function (data) {
 						alert('등록 완료!');
-						console.log(formData);
+						window.location.reload();
 					},
-					error: function (data) {
-						alert('유효한 값을 입력해주세요!');
+					error: function (request, status, error) {
+						if (
+							request.responseText ==
+							'{"statusCode":400,"message":"Ad is already registered","error":"Bad Request"}'
+						) {
+							alert('이미 등록된 광고입니다.');
+						} else {
+							alert('유효한 값을 입력해주세요!');
+						}
 					},
 				});
-			} else {
 			}
 		});
 	});
@@ -242,6 +249,7 @@ $(document).ready(function () {
 						headers: { Authorization: 'Bearer ' + accessToken },
 						success: function (data) {
 							alert('변경 완료!');
+							window.location.reload();
 						},
 						error: function (data) {
 							alert('유효한 값을 입력해주세요!');

--- a/src/public/js/ad.js
+++ b/src/public/js/ad.js
@@ -264,6 +264,7 @@ $(document).ready(function () {
 					headers: { Authorization: 'Bearer ' + accessToken },
 					success: function (data) {
 						alert('삭제 완료!');
+						window.location.reload();
 					},
 					error: function (data) {
 						console.log(data);
@@ -271,7 +272,6 @@ $(document).ready(function () {
 				});
 				$('.popup').hide();
 				$('.backon').hide();
-				location.reload();
 			} else {
 			}
 		});

--- a/src/public/js/ad.js
+++ b/src/public/js/ad.js
@@ -57,11 +57,6 @@ $(document).ready(function () {
 						},
 					},
 				],
-				fnDrawCallback: function () {
-					if ($(this).find('.dataTables_empty').length == 1) {
-						empty = 'true';
-					}
-				},
 				ordering: true,
 				lengthChange: false,
 				pagingType: 'full_numbers',
@@ -132,38 +127,37 @@ $(document).ready(function () {
 	});
 
 	$('#list_table').on('click', 'td', function () {
-		if (empty != 'true') {
+		var row_data = table.row(this).data();
+		if (typeof row_data != 'undefined') {
 			$('.popup-detail').show();
 			$('.ad-body').empty();
-			var row_data = table.row(this).data();
-
-			$.ajax({
-				url: '/admins/ads/' + row_data.id,
-				type: 'GET',
-				dataType: 'json',
-				dataSrc: '',
-				headers: { Authorization: 'Bearer ' + accessToken },
-				success: function (adform) {
-					var img_data = '<img src="' + adform.photoUrl + '" alt="license">';
-					$('.modal-body').append('<div> 회사명 : ' + adform.businessName + '</div>');
-					$('.modal-body').append('<div> 위치 : ' + adform.address + '</div>');
-					$('.modal-body').append('<div> 이메일 : ' + adform.email + '</div>');
-					$('.modal-body').append(
-						'<div> 홈페이지 : <a href = "' +
-							adform.pageUrl +
-							'" target="_blank">' +
-							adform.pageUrl +
-							'</a></div>',
-					);
-					$('.modal-body').append('<div>광고 배너</div>');
-					$('.modal-body').append(img_data);
-					$('body').append('<div class="backon"></div>');
-				},
-				error: function (response) {
-					alert(response.responseText);
-				},
-			});
 		}
+		$.ajax({
+			url: '/admins/ads/' + row_data.id,
+			type: 'GET',
+			dataType: 'json',
+			dataSrc: '',
+			headers: { Authorization: 'Bearer ' + accessToken },
+			success: function (adform) {
+				var img_data = '<img src="' + adform.photoUrl + '" alt="license">';
+				$('.modal-body').append('<div> 회사명 : ' + adform.businessName + '</div>');
+				$('.modal-body').append('<div> 위치 : ' + adform.address + '</div>');
+				$('.modal-body').append('<div> 이메일 : ' + adform.email + '</div>');
+				$('.modal-body').append(
+					'<div> 홈페이지 : <a href = "' +
+						adform.pageUrl +
+						'" target="_blank">' +
+						adform.pageUrl +
+						'</a></div>',
+				);
+				$('.modal-body').append('<div>광고 배너</div>');
+				$('.modal-body').append(img_data);
+				$('body').append('<div class="backon"></div>');
+			},
+			error: function (response) {
+				alert(response.responseText);
+			},
+		});
 
 		$('.btn-edit').click(function () {
 			$('.ad-body').empty();

--- a/src/public/js/admin-main.js
+++ b/src/public/js/admin-main.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
 		dataSrc: '',
 		headers: { Authorization: 'Bearer ' + accessToken },
 		success: function (response) {
-			table = $('#list_table').DataTable({
+			table = $('.ad-request').DataTable({
 				data: response,
 				columns: [
 					{
@@ -44,7 +44,7 @@ $(document).ready(function () {
 					{
 						data: null,
 						render: function (data) {
-							return "<button class='btn btn-detail' type='button'>자세히보기</button>";
+							return "<button class='btn request-detail' type='button'>자세히보기</button>";
 						},
 					},
 				],
@@ -65,8 +65,62 @@ $(document).ready(function () {
 		},
 	});
 
-	$(document).on('click', '.btn-detail', function () {
+	$(document).on('click', '.request-detail', function () {
 		location.href = '/admin/ad-request';
+	});
+
+	$.ajax({
+		url: '/admins/adsAll',
+		type: 'Get',
+		dataType: 'json',
+		dataSrc: '',
+		headers: { Authorization: 'Bearer ' + accessToken },
+		success: function (response) {
+			table = $('.ad-register').DataTable({
+				data: response,
+				columns: [
+					{
+						data: null,
+						render: function (data, type, row, meta) {
+							return meta.row + meta.settings._iDisplayStart + 1;
+						},
+					},
+					{ data: 'businessName' },
+					{ data: 'email' },
+					{
+						data: null,
+						title: 'DATE',
+						render: function (data) {
+							let date = '' + data.createdAt;
+							return date.substring(0, 10);
+						},
+					},
+					{
+						data: null,
+						render: function (data) {
+							return "<button class='btn register-detail' type='button'>자세히보기</button>";
+						},
+					},
+				],
+				ordering: false,
+				pageLength: 5,
+				lengthMenu: [
+					[5, 10, 20, -1],
+					[5, 10, 20, 'Todos'],
+				],
+				visible: false,
+				searching: false,
+				info: false,
+				autoWidth: false,
+			});
+		},
+		error: function (response) {
+			console.log(response.responseText);
+		},
+	});
+
+	$(document).on('click', '.register-detail', function () {
+		location.href = '/admin/ad';
 	});
 
 	$('.main_menu').click(function () {

--- a/src/views/ad-request.hbs
+++ b/src/views/ad-request.hbs
@@ -57,7 +57,7 @@
 					<a href='#'>광고 관리</a>
 					<ul class='sub_menu'>
 						<li><a href='/admin/ad-request'>요청 광고 확인</a></li>
-						<li><a href='#'>광고 등록 및 수정</a></li>
+						<li><a href='/admin/ad'>광고 등록 및 수정</a></li>
 					</ul>
 				</li>
 				<li class='main_menu'>

--- a/src/views/ad.hbs
+++ b/src/views/ad.hbs
@@ -1,0 +1,121 @@
+<html>
+	<head>
+		<meta charset='utf-8' />
+		<link rel='stylesheet' href='/css/ad.css' />
+		<script src='/lib/jquery-3.6.1.min.js'></script>
+		<script src='/js/ad.js'></script>
+		<link rel='preconnect' href='https://fonts.googleapis.com' />
+		<link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+		<link href='https://fonts.googleapis.com/css2?family=Nanum+Gothic&display=swap' rel='stylesheet' />
+		<link
+			rel='stylesheet'
+			href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0'
+		/>
+		<link
+			rel='stylesheet'
+			type='text/css'
+			href='https://cdn.datatables.net/1.13.1/css/dataTables.bootstrap4.min.css'
+		/>
+		<link
+			rel='stylesheet'
+			type='text/css'
+			href='https://cdn.datatables.net/responsive/2.4.0/css/responsive.bootstrap4.min.css'
+		/>
+		<script
+			type='text/javascript'
+			src='https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js'
+		></script>
+		<script type='text/javascript' src='https://cdn.datatables.net/1.13.1/js/jquery.dataTables.min.js'></script>
+		<script type='text/javascript' src='https://cdn.datatables.net/1.13.1/js/dataTables.bootstrap4.min.js'></script>
+		<script
+			type='text/javascript'
+			src='https://cdn.datatables.net/responsive/2.4.0/js/dataTables.responsive.min.js'
+		></script>
+		<script
+			type='text/javascript'
+			src='https://cdn.datatables.net/responsive/2.4.0/js/responsive.bootstrap4.min.js'
+		></script>
+	</head>
+	<body>
+
+		<div class='header'>
+			<div id='admin_page'>
+				<a>광고 등록 및 수정</a>
+				<div class='material-symbols-outlined logout'>
+					logout
+				</div>
+			</div>
+
+		</div>
+
+		<div class='container'>
+			<div class='home'>
+				<a href='/admin'> 지금, 여기 </a>
+			</div>
+			<ul id='menu'>
+				<li class='main_menu'>
+					<a href='#'>광고 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='/admin/ad-request'>요청 광고 확인</a></li>
+						<li><a href='/admin/ad'>광고 등록 및 수정</a></li>
+					</ul>
+				</li>
+				<li class='main_menu'>
+					<a href='#'>커뮤니티 관리</a>
+					<ul class='sub_menu'>
+						<li><a href='#'>신고 내역</a></li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+
+		<div class='ad'>
+			<button class='btn btn-update' type='button'>테이블 업데이트</button>
+			<button class='btn btn-register' type='button'>광고 등록</button>
+			<table id='list_table' class='list_table'>
+				<thead>
+					<tr>
+						<th>NO</th>
+						<th>BUSINESS</th>
+						<th>EMAIL</th>
+						<th>DATE</th>
+						<th>DETAIL</th>
+					</tr>
+				</thead>
+			</table>
+		</div>
+		<div class='popup popup-detail'>
+			<div class='modal-header'>
+				<span class='modal-title'>등록 상세 보기</span>
+				<span class='close'>X</span>
+			</div>
+			<div class='modal-body ad-body'>
+			</div>
+			<div class='modal-footer ad-footer'>
+				<button type='button' class='btn btn-edit'>Edit</button>
+				<button type='button' class='btn btn-delete'>Delete</button>
+			</div>
+		</div>
+
+		<div class='popup popup-register'>
+			<div class='modal-header'>
+				<span class='modal-title'>광고 등록</span>
+				<span class='close'>X</span>
+			</div>
+			<div class='modal-body ad-register-body'>
+				<form id='ad-register'>
+					<p>회사명 : <input class='input' type='text' name='businessName' /> </p>
+					<p>이메일 : <input class='input' type='email' name='email' /> </p>
+					<p>홈페이지 : <input class='input' type='text' name='pageUrl' /> </p>
+					<p>주소 :
+						<input class='input' type='text' placeholder='ex)인천 연수구 동춘2동' name='address' />
+					</p>
+					<p>광고 배너 업로드 : <input type='file' name='file' /> </p>
+					<div><button type='button' class='btn btn-submit'>등록</button></div>
+				</form>
+			</div>
+			<div class='modal-footer ad-register-footer'>
+			</div>
+		</div>
+	</body>
+</html>

--- a/src/views/admin-main.hbs
+++ b/src/views/admin-main.hbs
@@ -61,7 +61,7 @@
 					<a href='#'>광고 관리</a>
 					<ul class='sub_menu'>
 						<li><a href='/admin/ad-request'>요청 광고 확인</a></li>
-						<li><a href='#'>광고 등록 및 수정</a></li>
+						<li><a href='/admin/ad'>광고 등록 및 수정</a></li>
 					</ul>
 				</li>
 				<li class='main_menu'>

--- a/src/views/admin-main.hbs
+++ b/src/views/admin-main.hbs
@@ -78,7 +78,7 @@
 				<div class='manage_top'>
 					광고 요청 목록
 				</div>
-				<table id='list_table' class='list_table'>
+				<table class='list_table ad-request'>
 					<thead>
 						<tr>
 							<th>NO</th>
@@ -135,64 +135,18 @@
 		<div class='wrap'>
 			<div class='ad_reg_box box'>
 				<div class='manage_top'>
-					광고 및 수정 목록
+					광고 등록 및 수정 목록
 				</div>
-				<table>
+				<table class='list_table ad-register'>
 					<thead>
 						<tr>
-							<th>NAME</th><th>TELL</th><th>STATUS</th><th>REGISTER</th><th>MANAGEMENT</th>
+							<th>NO</th>
+							<th>BUSINESS</th>
+							<th>EMAIL</th>
+							<th>DATE</th>
+							<th>DETAIL</th>
 						</tr>
 					</thead>
-					<tbody>
-						<tr>
-							<td>A</td><td>02-123-4567</td><td>APPROVE</td><td>REGISTER</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-						<tr>
-							<td>B</td><td>031-452-9512</td><td>APPROVE</td><td>NOT REGISTER</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-						<tr>
-							<td>C</td><td>032-564-1231</td><td>APPROVE</td><td>NOT REGISTER</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-						<tr>
-							<td>D</td><td>02-461-8456</td><td>APPROVE</td><td>DELETE</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-						<tr>
-							<td>E</td><td>031-156-7865</td><td>APPROVE</td><td>REGISTER</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-						<tr>
-							<td>F</td><td>032-654-1234</td><td>APPROVE</td><td>REGISTER</td><td><button
-									class='btn'
-									type='button'
-								>
-									광고 관리
-								</button></td>
-						</tr>
-					</tbody>
 				</table>
 			</div>
 

--- a/src/views/view.controller.ts
+++ b/src/views/view.controller.ts
@@ -22,4 +22,9 @@ export class ViewController {
 	adRequestn(@Res() res: Response) {
 		return res.render('ad-request');
 	}
+
+	@Get('/ad')
+	ad(@Res() res: Response) {
+		return res.render('ad');
+	}
 }


### PR DESCRIPTION
> ### 작업개요
> * 광고 등록 및 수정 페이지 UI 디자인 후 각 API 연동했습니다.
>> ### 기능
>> * 광고 등록 모달 창에서 광고 등록 기능 (데이터 하나라도 비어있을 시, 잘못된 데이터 전송 시 경고 알람 창)
>> * 기존 테이블 기능 (이름순 정렬, 필터링, 페이지네이션 등)
>> * 각 row 클릭 시 해당하는 데이터 상세 창으로 팝업, 하단의 edit 클릭 시 광고 수정
>> * 수정 창에서 기존 데이터 placeholder로 보여줌
>> * 아무것도 입력하지 않을 시 데이터 전송하지 않고 입력한 값만 전송
>> * 하단의 delete 클릭 시 등록된 광고 삭제
>> ### 테스트
>> * 상기한 기능들 테스트 부탁드립니다
>> ### UI 디자인 사진
>> ![광고 등록](https://user-images.githubusercontent.com/108920053/205229132-520c2d8a-c938-44da-a267-8cdf547797b1.png)
>> ![광고 수정](https://user-images.githubusercontent.com/108920053/205229162-b2f352c7-3446-4074-9fd5-11e28347db2a.png)