### PR TITLE
Fix: Fix return spot with sns post to be retrieved

### DIFF
--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -97,7 +97,7 @@ export class RanksService {
 				.orderBy('after_rank', 'ASC')
 				.getRawMany();
 
-			const ranking = Array.from(rankingListSpots).map(function (spot) {
+			let ranking = Array.from(rankingListSpots).map(function (spot) {
 				return new RankingListResponseDto({
 					...spot,
 					rank: spot.after_rank,
@@ -107,6 +107,7 @@ export class RanksService {
 					photoUrl: spot.photo,
 				});
 			});
+			ranking = ranking.filter((spot) => spot.photoUrl !== null);
 			return new RankingResponseDto({
 				prev: week[0] ? week[0] : null,
 				next: week[1] ? week[1] : null,

--- a/src/modules/recommendations/recommendations.service.ts
+++ b/src/modules/recommendations/recommendations.service.ts
@@ -329,6 +329,7 @@ export class RecommendationsService {
 				.leftJoinAndSelect('spot.wishSpots', 'wishSpots')
 				.leftJoinAndSelect('spot.snsPosts', 'snsPosts')
 				.where('spot.id IN (:...spotIds)', { spotIds })
+				.andWhere('snsPosts.photoUrl is not null')
 				.getMany();
 
 			return spots;

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -327,9 +327,10 @@ export class SpotsService {
 				.leftJoinAndSelect('spot.clickSpots', 'clickSpots')
 				.leftJoinAndSelect('spot.wishSpots', 'wishSpots')
 				.leftJoinAndSelect('spot.snsPosts', 'snsPosts')
+				.where('snsPosts.photoUrl is not null')
 				.orderBy(`spot.${searchRequest.sorter}`, 'ASC');
 			if (searchRequest.word) {
-				searchSpots = searchSpots.where('spot.name Like :name', { name: `%${searchRequest.word}%` });
+				searchSpots = searchSpots.andWhere('spot.name Like :name', { name: `%${searchRequest.word}%` });
 			}
 			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -153,7 +153,8 @@ export class UsersService {
 				.leftJoinAndSelect('spot.clickSpots', 'clickSpots')
 				.leftJoinAndSelect('spot.wishSpots', 'wishSpots')
 				.leftJoinAndSelect('spot.snsPosts', 'snsPosts')
-				.where('user.id = :userId', { userId })
+				.where('snsPosts.photoUrl is not null')
+				.andWhere('user.id = :userId', { userId })
 				.orderBy('wishSpot.created_at', 'DESC');
 
 			const totalPageWishes = await wishes.getMany();


### PR DESCRIPTION
## 작업사항
- sns post없는 spot은 검색, 마이페이지, 랭킹, 추천 spot 리스트에서 나타나지 않도록 수정