### PR TITLE
Feat: Sort spots by view and popularity

### DIFF
--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -542,8 +542,8 @@ export class PostsService {
 
 			const totalPagePosts = await posts.getRawMany();
 			const responsePosts = await posts
-				.take(searchRequest.take)
-				.skip((searchRequest.page - 1) * searchRequest.take)
+				.limit(searchRequest.take)
+				.offset((searchRequest.page - 1) * searchRequest.take)
 				.getRawMany();
 
 			let order = totalPagePosts.length - (searchRequest.page - 1) * searchRequest.take;

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -497,14 +497,14 @@ export class PostsService {
 				.addSelect('user.id AS user, user.nickname AS name')
 				.addSelect((clicks) => {
 					return clicks
-						.select('COUNT (*)', 'clickPosts')
+						.select('COUNT (*)::int AS clicks')
 						.from(ClickPost, 'clickPosts')
 						.where('clickPosts.postId = post.id')
 						.limit(1);
 				}, 'clicks')
 				.addSelect((likes) => {
 					return likes
-						.select('COUNT (*)', 'likePosts')
+						.select('COUNT (*)::int AS likes')
 						.from(LikePost, 'likePosts')
 						.where('likePosts.postId = post.id')
 						.limit(1);
@@ -553,8 +553,8 @@ export class PostsService {
 					new MainPostsResponseDto({
 						...post,
 						order: order--,
-						views: +post.clicks,
-						likes: +post.likes,
+						views: post.clicks,
+						likes: post.likes,
 						createdAt: post.create,
 						photoUrls: post.photos,
 						isLike: post.likeUsers ? true : false,

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -75,14 +75,14 @@ export class RanksService {
 				}, 'before_rank')
 				.addSelect((wishes) => {
 					return wishes
-						.select('COUNT (*)', 'wishSpots')
+						.select('COUNT (*)::int AS wishes')
 						.from(WishSpot, 'wishSpots')
 						.where('wishSpots.spotId = spot.id')
 						.limit(1);
 				}, 'wishes')
 				.addSelect((clicks) => {
 					return clicks
-						.select('COUNT (*)', 'clickSpots')
+						.select('COUNT (*)::int AS clicks')
 						.from(ClickSpot, 'clickSpots')
 						.where('clickSpots.spotId = spot.id')
 						.limit(1);
@@ -103,8 +103,8 @@ export class RanksService {
 					...spot,
 					rank: rank++,
 					variance: spot.before_rank ? spot.before_rank - spot.after_rank : null,
-					views: +spot.clicks,
-					wishes: +spot.wishes,
+					views: spot.clicks,
+					wishes: spot.wishes,
 					photoUrl: spot.photo,
 				});
 			});

--- a/src/modules/spots/dto/search-request.dto.ts
+++ b/src/modules/spots/dto/search-request.dto.ts
@@ -14,10 +14,10 @@ export class SearchRequestDto {
 	@IsOptional()
 	@ApiProperty({
 		enum: SortType,
-		default: SortType.Name,
-		description: '정렬 기준 (이름순: Name, 인기순: Rank)',
+		default: SortType.View,
+		description: '정렬 기준 (조회순: View, 인기순: Wish, 랭킹순: Rank)',
 	})
-	readonly sorter?: SortType = SortType.Name;
+	readonly sorter?: SortType = SortType.View;
 
 	@IsNumber()
 	@IsOptional()

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -47,7 +47,7 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 			ApiQuery({
 				name: 'sorter',
 				required: false,
-				description: '정렬 기준 (이름순: Name, 인기순: Rank)',
+				description: '정렬 기준 (조회순: View, 인기순: Wish, 랭킹순: Rank)',
 			}),
 			ApiQuery({
 				name: 'page',

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -350,14 +350,14 @@ export class SpotsService {
 				.select('Distinct spot.id AS id, spot.address AS address, spot.name AS name, spot.rank AS rank')
 				.addSelect((clicks) => {
 					return clicks
-						.select('COUNT (*)', 'clickSpots')
+						.select('COUNT (*)::int AS clicks')
 						.from(ClickSpot, 'clickSpots')
 						.where('clickSpots.spotId = spot.id')
 						.limit(1);
 				}, 'clicks')
 				.addSelect((wishes) => {
 					return wishes
-						.select('COUNT (*)', 'wishSpots')
+						.select('COUNT (*)::int AS wishes')
 						.from(WishSpot, 'wishSpots')
 						.where('wishSpots.spotId = spot.id')
 						.limit(1);
@@ -413,8 +413,8 @@ export class SpotsService {
 					new SearchResponseDto({
 						...spot,
 						order: order--,
-						views: +spot.clicks,
-						wishes: +spot.wishes,
+						views: spot.clicks,
+						wishes: spot.wishes,
 						isWish,
 					}),
 				);

--- a/src/types/sort.types.ts
+++ b/src/types/sort.types.ts
@@ -1,4 +1,5 @@
 export enum SortType {
-	Name = 'Name',
+	View = 'View',
+	Wish = 'Wish',
 	Rank = 'Rank',
 }


### PR DESCRIPTION
## 작업사항
- spot 정렬: 이름순 없애고 조회순(View), 인기순(Wish), 랭크순(Rank)으로 정렬
- select count하고 나서 number 전환 형식 변경 -> COUNT (*)::int (spot, post, rank)