### PR TITLE
Fix: Fix rank issues after deleting db data

### DIFF
--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -52,7 +52,6 @@ export class RanksService {
 		try {
 			let rankingListSpotsQuery = this.spotsRepository
 				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
@@ -64,7 +63,6 @@ export class RanksService {
 				let rankIndex = 1;
 				const allOriginRankingsData = await this.spotsRepository
 					.createQueryBuilder('spot')
-					.innerJoinAndSelect('spot.location', 'location')
 					.innerJoinAndSelect('spot.rankings', 'rankings')
 					.where('rankings.date = :date', { date: rankingRequest.date })
 					.orderBy('rankings.rank', 'ASC')
@@ -83,7 +81,6 @@ export class RanksService {
 
 			rankingListSpotsQuery = this.spotsRepository
 				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
@@ -91,7 +88,6 @@ export class RanksService {
 
 			const rankingListSpots = await rankingListSpotsQuery
 				.select('spot.id AS id, spot.name AS name, spot.address AS address')
-				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
 				.addSelect((afterRank) => {
 					return afterRank
 						.select('rankings.rank', 'after_rank')
@@ -159,7 +155,6 @@ export class RanksService {
 
 			let rankingMapSpotsQuery = this.spotsRepository
 				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
@@ -171,7 +166,6 @@ export class RanksService {
 				let rankIndex = 1;
 				const allOriginRankingsData = await this.spotsRepository
 					.createQueryBuilder('spot')
-					.innerJoinAndSelect('spot.location', 'location')
 					.innerJoinAndSelect('spot.rankings', 'rankings')
 					.where('rankings.date = :date', { date: rankingRequest.date })
 					.orderBy('rankings.rank', 'ASC')
@@ -190,7 +184,6 @@ export class RanksService {
 
 			rankingMapSpotsQuery = this.spotsRepository
 				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.location', 'location')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
@@ -200,7 +193,6 @@ export class RanksService {
 				.select(
 					'spot.id AS id, spot.name AS name, spot.latitude AS latitude, spot.longitude AS longitude, spot.address AS address',
 				)
-				.addSelect('location.id AS location_id, location.metroName AS metro, location.localName AS local')
 				.addSelect((currentRank) => {
 					return currentRank
 						.select('rankings.rank', 'current_rank')

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -47,46 +47,39 @@ export class RanksService {
 	}
 
 	async getRanksList(rankingRequest: RankingRequestDto) {
-		const week = await this.weekCalulation(rankingRequest);
-
 		try {
-			let rankingListSpotsQuery = this.spotsRepository
-				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.rankings', 'rankings')
-				.where('rankings.date = :date', { date: rankingRequest.date })
-				.andWhere('rankings.rank >= 1')
-				.andWhere('rankings.rank <= 20');
+			const week = await this.weekCalulation(rankingRequest);
 
-			const rankingListSpotsQueryData = await rankingListSpotsQuery.orderBy('rankings.rank', 'ASC').getMany();
+			const rankingListQuery = await this.ranksRepository
+				.createQueryBuilder('rank')
+				.where('rank.date = :date', { date: rankingRequest.date })
+				.andWhere('rank.rank >= 1')
+				.andWhere('rank.rank <= 20')
+				.orderBy('rank.rank', 'ASC')
+				.getMany();
 
-			if (rankingListSpotsQueryData.length !== 20) {
+			if (rankingListQuery.length !== 20) {
 				let rankIndex = 1;
-				const allOriginRankingsData = await this.spotsRepository
-					.createQueryBuilder('spot')
-					.innerJoinAndSelect('spot.rankings', 'rankings')
-					.where('rankings.date = :date', { date: rankingRequest.date })
-					.orderBy('rankings.rank', 'ASC')
+				const allOriginRankingsData = await this.ranksRepository
+					.createQueryBuilder('rank')
+					.where('rank.date = :date', { date: rankingRequest.date })
+					.orderBy('rank.rank', 'ASC')
 					.getMany();
 
 				for (const allOriginRanking of allOriginRankingsData) {
-					await this.ranksRepository.update(
-						{ spotId: allOriginRanking.id },
-						{
-							rank: rankIndex++,
-						},
-					);
+					await this.ranksRepository.update(allOriginRanking.id, {
+						rank: rankIndex++,
+					});
 					if (rankIndex === 21) break;
 				}
 			}
 
-			rankingListSpotsQuery = this.spotsRepository
+			const rankingListSpots = await this.spotsRepository
 				.createQueryBuilder('spot')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
-				.andWhere('rankings.rank <= 20');
-
-			const rankingListSpots = await rankingListSpotsQuery
+				.andWhere('rankings.rank <= 20')
 				.select('spot.id AS id, spot.name AS name, spot.address AS address')
 				.addSelect((afterRank) => {
 					return afterRank
@@ -153,43 +146,36 @@ export class RanksService {
 		try {
 			const week = await this.weekCalulation(rankingRequest);
 
-			let rankingMapSpotsQuery = this.spotsRepository
-				.createQueryBuilder('spot')
-				.innerJoinAndSelect('spot.rankings', 'rankings')
-				.where('rankings.date = :date', { date: rankingRequest.date })
-				.andWhere('rankings.rank >= 1')
-				.andWhere('rankings.rank <= 20');
+			const rankingMapQuery = await this.ranksRepository
+				.createQueryBuilder('rank')
+				.where('rank.date = :date', { date: rankingRequest.date })
+				.andWhere('rank.rank >= 1')
+				.andWhere('rank.rank <= 20')
+				.orderBy('rank.rank', 'ASC')
+				.getMany();
 
-			const rankingMapSpotsQueryData = await rankingMapSpotsQuery.orderBy('rankings.rank', 'ASC').getMany();
-
-			if (rankingMapSpotsQueryData.length !== 20) {
+			if (rankingMapQuery.length !== 20) {
 				let rankIndex = 1;
-				const allOriginRankingsData = await this.spotsRepository
-					.createQueryBuilder('spot')
-					.innerJoinAndSelect('spot.rankings', 'rankings')
-					.where('rankings.date = :date', { date: rankingRequest.date })
-					.orderBy('rankings.rank', 'ASC')
+				const allOriginRankingsData = await this.ranksRepository
+					.createQueryBuilder('rank')
+					.where('rank.date = :date', { date: rankingRequest.date })
+					.orderBy('rank.rank', 'ASC')
 					.getMany();
 
 				for (const allOriginRanking of allOriginRankingsData) {
-					await this.ranksRepository.update(
-						{ spotId: allOriginRanking.id },
-						{
-							rank: rankIndex++,
-						},
-					);
+					await this.ranksRepository.update(allOriginRanking.id, {
+						rank: rankIndex++,
+					});
 					if (rankIndex === 21) break;
 				}
 			}
 
-			rankingMapSpotsQuery = this.spotsRepository
+			const rankingMapSpots = await this.spotsRepository
 				.createQueryBuilder('spot')
 				.innerJoinAndSelect('spot.rankings', 'rankings')
 				.where('rankings.date = :date', { date: rankingRequest.date })
 				.andWhere('rankings.rank >= 1')
-				.andWhere('rankings.rank <= 20');
-
-			const rankingMapSpots = await rankingMapSpotsQuery
+				.andWhere('rankings.rank <= 20')
 				.select(
 					'spot.id AS id, spot.name AS name, spot.latitude AS latitude, spot.longitude AS longitude, spot.address AS address',
 				)

--- a/src/modules/recommendations/recommendations.service.ts
+++ b/src/modules/recommendations/recommendations.service.ts
@@ -255,7 +255,7 @@ export class RecommendationsService {
 											.then(async function () {
 												await ssh
 													.execCommand(
-														`bash "/home/iknow/Desktop/blackcoffee/placeRecommender/run_training.sh" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_taste_themes.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_spots.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_wish_spots.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_click_spots.json" True`,
+														`bash "/home/iknow/Desktop/blackcoffee/placeRecommender/run_training.sh" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_taste_themes.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_spots.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_click_spots.json" "/home/iknow/Desktop/blackcoffee/placeRecommender/testingData/input_wish_spots.json" True`,
 														{},
 													)
 													.then(async function () {


### PR DESCRIPTION
## 개요
- 중간 중간 데이터셋을 관리할 때마다 삭제되는 데이터 때문에 랭크 반환 시 이슈가 있었습니다.
- 이슈 해결을 위해 랭크 반환 때마다 1~20위의 데이터들 중 빠진 데이터가 있다면 rank db를 Update하는 기능을 추가했습니다.
- 이를 위해 ml에서 이번주 rank를 받아올 때 1~20까지만 받아오는 것이 아니라 모든 rank를 받아오는 것으로 정했습니다.
- 저번에 예은님이 임의로 1~20까지 부여하는 코드는 삭제했습니다.
## 테스트
- rank table에 1~마지막 순위(최소 30? 정도)까지 데이터를 넣어두고 1~20위 내의 데이터들 중 몇개를 삭제한 다음 get rank api 테스트 부탁드려요. 1~20위까지 잘 나오는지, rank db가 update 되었는지