### PR TITLE
Feat: Add Send all snspost to ML func

### DIFF
--- a/src/modules/spots/dto/ml-sns-request.dto.ts
+++ b/src/modules/spots/dto/ml-sns-request.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class MlSnsRequestDto {
+	#decideWeek = (createdAt: string): number => {
+		const currentDate = new Date(createdAt);
+		let year = currentDate.getFullYear();
+		let month = currentDate.getMonth() + 1;
+
+		const weekNumByThur = (currentDate) => {
+			const year = currentDate.getFullYear();
+			const month = currentDate.getMonth();
+			const date = currentDate.getDate();
+
+			const firstDate = new Date(year, month, 1);
+			const lastDate = new Date(year, month + 1, 0);
+			const firstDayOfWeek = firstDate.getDay() ? firstDate.getDay() : 7;
+			const lastDayOfWeek = lastDate.getDay();
+			const lastDay = lastDate.getDate();
+
+			const firstWeekCheck = firstDayOfWeek === 5 || firstDayOfWeek === 6 || firstDayOfWeek === 7 ? true : false;
+			const lastWeekCheck = lastDayOfWeek === 1 || lastDayOfWeek === 2 || lastDayOfWeek === 3 ? true : false;
+
+			const lastWeekNo = Math.ceil((firstDayOfWeek - 1 + lastDay) / 7);
+
+			let weekNo = Math.ceil((firstDayOfWeek - 1 + date) / 7);
+			if (weekNo === 1 && firstWeekCheck) weekNo = -1;
+			else if (weekNo === lastWeekNo && lastWeekCheck) weekNo = -2;
+			else if (firstWeekCheck) weekNo = weekNo - 1;
+			return weekNo;
+		};
+
+		let weekNo = weekNumByThur(currentDate);
+		if (weekNo === -1) {
+			const afterDate = new Date(year, month - 1, 0);
+			year = month === 1 ? year - 1 : year;
+			month = month === 1 ? 12 : month - 1;
+			weekNo = weekNumByThur(afterDate);
+		}
+		if (weekNo === -2) {
+			year = month === 12 ? year + 1 : year;
+			month = month === 12 ? 1 : month + 1;
+			weekNo = 1;
+		}
+		const date = ''.concat(year.toString(), month.toString().padStart(2, '0'), weekNo.toString());
+		return +date;
+	};
+
+	@IsNumber()
+	@ApiProperty({ example: 1, description: 'sns 게시글 좋아요 개수' })
+	readonly likeNumber: number;
+
+	@IsNumber()
+	@Type(() => Number)
+	@ApiProperty({ example: 2022113, description: '날짜(연도 + 월 + 주차)' })
+	readonly week: number;
+
+	constructor({ likeNumber, week }) {
+		this.likeNumber = likeNumber;
+		this.week = this.#decideWeek(week);
+	}
+}

--- a/src/modules/spots/dto/ml-spot-sns-request.dto.ts
+++ b/src/modules/spots/dto/ml-spot-sns-request.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+import { MlSnsRequestDto } from './ml-sns-request.dto';
+
+export class MlSpotSnsRequestDto {
+	@IsNumber()
+	@ApiProperty({ example: 1, description: '여행지 id' })
+	readonly spotId: number;
+
+	@ApiProperty({ description: 'sns 게시글 정보' })
+	readonly snsPosts: MlSnsRequestDto[];
+
+	constructor({ spotId, snsPosts }) {
+		this.spotId = spotId;
+		this.snsPosts = snsPosts;
+	}
+}

--- a/src/modules/spots/spots.controller.ts
+++ b/src/modules/spots/spots.controller.ts
@@ -25,6 +25,11 @@ import { SpotsService } from './spots.service';
 export class SpotsController {
 	constructor(private readonly spotsService: SpotsService) {}
 
+	@Get('/test-ml')
+	async mltest() {
+		return await this.spotsService.sendAllSnsPostsToMl();
+	}
+
 	@Post()
 	@ApiDocs.createSpots('csv 파일 속 데이터를 DB에 저장')
 	@UseInterceptors(

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -135,4 +135,17 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	mltest(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: 'sns post url들 파일(test.txt)로 출력 (테스트위해)',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: Boolean,
+			}),
+		);
+	},
 };


### PR DESCRIPTION
- 모든 주차의 랭킹을 ml로부터 받기 위해 모든 sns게시글을 ml로 보내고 랭킹을 받는 기능을 추가했습니다.
- 기존에 있던 POST /spots api에 추가할 예정입니다.
- 추후 작업 예정 : 예은님이 ml로부터 받은 데이터를 rank table에 update & insert 하는 기능 추가