### PR TITLE
Feat: Return iswish when the user steamed in the ranking

### DIFF
--- a/src/modules/ranks/dto/ranking-list-response.dto.ts
+++ b/src/modules/ranks/dto/ranking-list-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsNumber, IsString } from 'class-validator';
 
 export class RankingListResponseDto {
 	@IsNumber()
@@ -34,7 +34,11 @@ export class RankingListResponseDto {
 	@ApiProperty({ example: 'https://scontent~', description: '여행지 사진 링크' })
 	readonly photoUrl: string;
 
-	constructor({ id, name, address, rank, variance, views, wishes, photoUrl }) {
+	@IsBoolean()
+	@ApiProperty({ example: false, description: '여행지 찜하기 여부' })
+	readonly isWish: boolean;
+
+	constructor({ id, name, address, rank, variance, views, wishes, photoUrl, isWish }) {
 		this.id = id;
 		this.name = name;
 		this.address = address;
@@ -43,5 +47,6 @@ export class RankingListResponseDto {
 		this.views = views;
 		this.wishes = wishes;
 		this.photoUrl = photoUrl;
+		this.isWish = isWish;
 	}
 }

--- a/src/modules/ranks/ranks.controller.ts
+++ b/src/modules/ranks/ranks.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Headers } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { RankingRequestDto } from './dto/ranking-request.dto';
@@ -12,8 +12,8 @@ export class RanksController {
 
 	@Get('/list')
 	@ApiDocs.ranksList('최신 트렌드 랭킹 페이지 리스트 기준')
-	async ranksList(@Query() rankingRequest: RankingRequestDto) {
-		return await this.ranksService.getRanksList(rankingRequest);
+	async ranksList(@Headers() headers, @Query() rankingRequest: RankingRequestDto) {
+		return await this.ranksService.getRanksList(headers.authorization, rankingRequest);
 	}
 
 	@Get('/map')

--- a/src/modules/ranks/ranks.docs.ts
+++ b/src/modules/ranks/ranks.docs.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 
 import { SwaggerMethodDoc } from 'src/swagger/swagger-method-doc-type';
 import { RankingResponseDto } from './dto/ranking-response.dto';
@@ -22,6 +22,7 @@ export const ApiDocs: SwaggerMethodDoc<RanksController> = {
 				description: '',
 				type: RankingResponseDto,
 			}),
+			ApiBearerAuth('Authorization'),
 		);
 	},
 	ranksMap(summary: string) {

--- a/src/modules/ranks/ranks.module.ts
+++ b/src/modules/ranks/ranks.module.ts
@@ -1,13 +1,21 @@
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
 
 import { Spot } from 'src/entities/spots.entity';
 import { Rank } from 'src/entities/rank.entity';
+import { WishSpot } from 'src/entities/wish-spots.entity';
 import { RanksController } from './ranks.controller';
 import { RanksService } from './ranks.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Spot, Rank])],
+	imports: [
+		TypeOrmModule.forFeature([Spot, Rank, WishSpot]),
+		JwtModule.register({
+			secret: process.env.JWT_ACCESS_TOKEN_SECRET,
+			signOptions: { expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME },
+		}),
+	],
 
 	controllers: [RanksController],
 	providers: [RanksService],

--- a/src/modules/spots/spots.docs.ts
+++ b/src/modules/spots/spots.docs.ts
@@ -76,6 +76,7 @@ export const ApiDocs: SwaggerMethodDoc<SpotsController> = {
 				description: '',
 				type: SearchPageResponseDto,
 			}),
+			ApiBearerAuth('Authorization'),
 		);
 	},
 	updateSnsPostPhotos(summary: string) {


### PR DESCRIPTION
## 작업사항
- 랭킹 리스트에서 header를 받아서 isWish를 추가하는 작업하였습니다.

## 테스트
- isWish 여부
- ranking list에서 찜한 사용자 일 때, 아닐 때 반환 값 확인