### PR TITLE
Feat: Update overall week ranking

### DIFF
--- a/src/modules/ranks/dto/ranks-update-request.dto.ts
+++ b/src/modules/ranks/dto/ranks-update-request.dto.ts
@@ -3,6 +3,10 @@ import { IsNumber } from 'class-validator';
 
 export class RanksUpdateRequestDto {
 	@IsNumber()
+	@ApiProperty({ example: 2022122, description: '날짜(연도 + 월 + 주차)' })
+	readonly week: number;
+
+	@IsNumber()
 	@ApiProperty({ example: 1, description: '여행지 id' })
 	readonly spotId: number;
 
@@ -10,7 +14,8 @@ export class RanksUpdateRequestDto {
 	@ApiProperty({ example: 1, description: '순위' })
 	readonly rank: number;
 
-	constructor({ spotId, rank }) {
+	constructor({ week, spotId, rank }) {
+		this.week = week;
 		this.spotId = spotId;
 		this.rank = rank;
 	}

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -241,17 +241,17 @@ export class RanksService {
 			const rank = await this.ranksRepository.findOne({
 				where: { date: updateRequest.week, rank: updateRequest.rank },
 			});
-			if (rank && rank.spotId !== updateRequest.spotId) {
-				await this.ranksRepository.update(
-					{ date: updateRequest.week, rank: updateRequest.rank },
-					{ spotId: updateRequest.spotId },
-				);
-			}
-			if (!rank && updateRequest.rank) {
+			if (rank) {
+				if (rank.spotId !== updateRequest.spotId) {
+					await this.ranksRepository.update(
+						{ date: updateRequest.week, rank: updateRequest.rank },
+						{ spotId: updateRequest.spotId },
+					);
+				}
+			} else {
 				const ranksRequestDto = new RanksRecordRequestDto({
 					date: updateRequest.week,
-					spotId: updateRequest.spotId,
-					rank: updateRequest.rank,
+					...updateRequest,
 				});
 				await this.ranksRepository.save(ranksRequestDto);
 			}

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -238,21 +238,18 @@ export class RanksService {
 
 	async updateRank(updateRequest: RanksUpdateRequestDto) {
 		try {
-			await this.spotsRepository.update(updateRequest.spotId, { rank: updateRequest.rank });
-
-			const rankingRequestDto = new RankingRequestDto();
 			const rank = await this.ranksRepository.findOne({
-				where: { date: rankingRequestDto.getDate, rank: updateRequest.rank },
+				where: { date: updateRequest.week, rank: updateRequest.rank },
 			});
 			if (rank && rank.spotId !== updateRequest.spotId) {
 				await this.ranksRepository.update(
-					{ date: rankingRequestDto.getDate, rank: updateRequest.rank },
+					{ date: updateRequest.week, rank: updateRequest.rank },
 					{ spotId: updateRequest.spotId },
 				);
 			}
 			if (!rank && updateRequest.rank) {
 				const ranksRequestDto = new RanksRecordRequestDto({
-					date: rankingRequestDto.getDate,
+					date: updateRequest.week,
 					spotId: updateRequest.spotId,
 					rank: updateRequest.rank,
 				});

--- a/src/modules/ranks/ranks.service.ts
+++ b/src/modules/ranks/ranks.service.ts
@@ -241,20 +241,13 @@ export class RanksService {
 			const rank = await this.ranksRepository.findOne({
 				where: { date: updateRequest.week, rank: updateRequest.rank },
 			});
-			if (rank) {
-				if (rank.spotId !== updateRequest.spotId) {
-					await this.ranksRepository.update(
-						{ date: updateRequest.week, rank: updateRequest.rank },
-						{ spotId: updateRequest.spotId },
-					);
-				}
-			} else {
-				const ranksRequestDto = new RanksRecordRequestDto({
-					date: updateRequest.week,
-					...updateRequest,
-				});
-				await this.ranksRepository.save(ranksRequestDto);
-			}
+			if (rank) await this.ranksRepository.delete(rank.id);
+
+			const ranksRequestDto = new RanksRecordRequestDto({
+				date: updateRequest.week,
+				...updateRequest,
+			});
+			await this.ranksRepository.save(ranksRequestDto);
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);
 		}

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -23,6 +23,8 @@ import { Theme } from 'src/entities/theme.entity';
 import { WishSpot } from 'src/entities/wish-spots.entity';
 import { SortType } from 'src/types/sort.types';
 import { Repository } from 'typeorm';
+import { RanksUpdateRequestDto } from '../ranks/dto/ranks-update-request.dto';
+import { RanksService } from '../ranks/ranks.service';
 import { DetailSnsPostResponseDto } from './dto/detail-sns-post-response.dto';
 import { DetailSpotRequestDto } from './dto/detail-spot-request.dto';
 import { DetailSpotResponseDto } from './dto/detail-spot-response.dto';
@@ -54,7 +56,7 @@ export class SpotsService {
 		private readonly clickSpotsRepository: Repository<ClickSpot>,
 		@InjectRepository(WishSpot)
 		private readonly wishSpotsRepository: Repository<WishSpot>,
-		//private readonly ranksService: RanksService,
+		private readonly ranksService: RanksService,
 		private readonly configService: ConfigService,
 		private readonly httpService: HttpService,
 		private readonly jwtService: JwtService,
@@ -211,7 +213,17 @@ export class SpotsService {
 			);
 		const resultFile = fs.readFileSync(localResultPath);
 		const resultJson = JSON.parse(resultFile.toString());
-		console.log(resultJson);
+		return await this.createRanks(resultJson);
+	}
+
+	private async createRanks(resultJson) {
+		for (const week of resultJson) {
+			for (const rank of week.ranks) {
+				await this.ranksService.updateRank(
+					new RanksUpdateRequestDto({ week: week.week, spotId: rank.spotId, rank: rank.rank }),
+				);
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
## 작업사항
- ml서버에서 받은 JSON으로 전체 주차 모두 최대 50개까지 Rank Table에 Delete 및 Save 하는 로직으로 변경하였습니다.