### PR TITLE
Feat: Change english name search to be possible regardless of case

### DIFF
--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -518,7 +518,7 @@ export class PostsService {
 				}, 'likeUsers');
 
 			if (searchRequest.word) {
-				posts = posts.where('post.title Like :title', { title: `%${searchRequest.word}%` });
+				posts = posts.where('LOWER(post.title) Like LOWER(:title)', { title: `%${searchRequest.word}%` });
 			}
 			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -518,7 +518,9 @@ export class PostsService {
 				}, 'likeUsers');
 
 			if (searchRequest.word) {
-				posts = posts.where('LOWER(post.title) Like LOWER(:title)', { title: `%${searchRequest.word}%` });
+				posts = posts.where(`REPLACE(LOWER(post.title), ' ', '') Like LOWER(:title)`, {
+					title: `%${searchRequest.word.split(' ').join('')}%`,
+				});
 			}
 			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -465,7 +465,9 @@ export class SpotsService {
 				.where('snsPosts.photoUrl is not null')
 				.distinct(true);
 			if (searchRequest.word) {
-				searchSpots = searchSpots.andWhere('spot.name Like :name', { name: `%${searchRequest.word}%` });
+				searchSpots = searchSpots.andWhere('LOWER(spot.name) Like LOWER(:name)', {
+					name: `%${searchRequest.word}%`,
+				});
 			}
 			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {
 				let locationIds = searchRequest.locationIds;

--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -465,8 +465,8 @@ export class SpotsService {
 				.where('snsPosts.photoUrl is not null')
 				.distinct(true);
 			if (searchRequest.word) {
-				searchSpots = searchSpots.andWhere('LOWER(spot.name) Like LOWER(:name)', {
-					name: `%${searchRequest.word}%`,
+				searchSpots = searchSpots.andWhere(`REPLACE(LOWER(spot.name), ' ', '') Like LOWER(:name)`, {
+					name: `%${searchRequest.word.split(' ').join('')}%`,
 				});
 			}
 			if (searchRequest.locationIds && searchRequest.locationIds[0] !== 0) {


### PR DESCRIPTION
## 작업사항
- Spot, Post 검색하는 조건을 포괄적으로 변경하였습니다.
1. 대소문자 관계없이 영어 이름 검색 가능하도록 변경
2. 공백 상관없이 검색 가능하도록 변경