### PR TITLE
Fix: Fix update sns post photo-url api

### DIFF
--- a/src/modules/spots/spots.service.ts
+++ b/src/modules/spots/spots.service.ts
@@ -270,13 +270,14 @@ export class SpotsService {
 				for (const spot of snsPostsSpot) {
 					deleteSpotIds.push(spot.id);
 				}
-
-				await this.spotsRepository
-					.createQueryBuilder('spot')
-					.delete()
-					.from(Spot)
-					.where('id IN (:...ids)', { ids: deleteSpotIds })
-					.execute();
+				if (deleteSpotIds.length > 0) {
+					await this.spotsRepository
+						.createQueryBuilder('spot')
+						.delete()
+						.from(Spot)
+						.where('id IN (:...ids)', { ids: deleteSpotIds })
+						.execute();
+				}
 			} else {
 				await this.snsPostRepository.update(
 					{


### PR DESCRIPTION
- photourl 업데이트 시 빈배열의 Id를 삭제할 때 에러가 있어 수정했습니다.